### PR TITLE
corrected similar listings returning duplicates

### DIFF
--- a/ozpcenter/api/listing/model_access.py
+++ b/ozpcenter/api/listing/model_access.py
@@ -196,7 +196,7 @@ def get_similar_listings(username, original_listing_id):
     original_listing_category = get_listing_by_id(username, original_listing_id).categories.all()
 
     try:
-        return models.Listing.objects.for_user(username).filter(categories=original_listing_category)
+        return models.Listing.objects.for_user(username).filter(categories=original_listing_category).distinct()
     except ObjectDoesNotExist:
         return None
 


### PR DESCRIPTION
prior behavior: duplicates were returning from the similar endpoint
desired behavior: no duplicates returned from the similar endpoint

To test:  GET http://localhost:8001/api/listing/1/similar/