### PR TITLE
Update model_access.py

### DIFF
--- a/ozpcenter/api/storefront/model_access.py
+++ b/ozpcenter/api/storefront/model_access.py
@@ -618,7 +618,7 @@ def get_metadata(username):
             # i['icon'] = '/TODO'
             i['listing_count'] = models.Listing.objects.for_user(
                 username).filter(agency__title=i['title'],
-                approval_status=models.Listing.APPROVED,is_enabled=True).count()
+                approval_status=models.Listing.APPROVED, is_enabled=True).count()
 
         for i in data['intents']:
             # i['icon'] = models.Image.objects.get(id=i['icon']).image_url()

--- a/ozpcenter/api/storefront/model_access.py
+++ b/ozpcenter/api/storefront/model_access.py
@@ -618,7 +618,7 @@ def get_metadata(username):
             # i['icon'] = '/TODO'
             i['listing_count'] = models.Listing.objects.for_user(
                 username).filter(agency__title=i['title'],
-                approval_status=models.Listing.APPROVED).count()
+                approval_status=models.Listing.APPROVED,is_enabled=True).count()
 
         for i in data['intents']:
             # i['icon'] = models.Image.objects.get(id=i['icon']).image_url()


### PR DESCRIPTION
**Issue:**

- In at least two situations, the count next to the Organization in the Organizations dropdown list does not match the number of results that come back when clicking the Organization.
- Example: One Organization displays 11, returns 9 listings 
- However, under Listing Management the count is 11 for Published and all 11 display when filtered by that Organization.

**Acceptance Criteria:**

- Search>Organizations (filter)> Organization count is a total of Published+Enabled listings for that organization

**This bug had the following issues affecting the count displayed:**

1. Mismatched results depending on backend node returned by load balancer due to elastic search index not running during/after update (resolved by Soe)
2. Backend code was not filtering out disabled listings (resolved by Russell)
3. One listing did not have security marking (resolved by Soe)