### PR TITLE
Fix ordering of recommendations to original scoring order

### DIFF
--- a/ozpcenter/api/storefront/model_access.py
+++ b/ozpcenter/api/storefront/model_access.py
@@ -513,10 +513,15 @@ def get_storefront(username, pre_fetch=False):
                                                                                                                                   is_enabled=True,
                                                                                                                                   is_deleted=False).all()
 
-            recommended_listings_raw = listing_serializers.ListingSerializer.setup_eager_loading(recommended_listings_queryset)
-
             if pre_fetch:
-                recommended_listings_raw = [recommendations_listing for recommendations_listing in recommended_listings_raw]
+                recommended_listings_raw = listing_serializers.ListingSerializer.setup_eager_loading(recommended_listings_queryset)
+
+            id_recommended_object_mapper = {}
+
+            for recommendation_entry in recommended_listings_queryset:
+                id_recommended_object_mapper[recommendation_entry.id] = recommendation_entry
+
+            recommended_listings_raw = [id_recommended_object_mapper[listing_id] for listing_id in listing_ids_list]
 
             # Post security_marking check - lazy loading
             recommended_listings = pipeline.Pipeline(recommend_utils.ListIterator([recommendations_listing for recommendations_listing in recommended_listings_raw]),


### PR DESCRIPTION
Please Review the changes that resolve a reordering of the bookmarks on retrieval compared to what they were supposed to be when ranked.  This change causes the rank to be preserved when retrieving recommended list.
To Test:
Pull Main Branch and run: make recommend
Then check out the recommended list for bettafish user and make note of all of the apps that are recommended
Pull recommender_fix branch and run: make recommend
Then check out the recommended list for the same user and it should be different

(If more detail is needed add a print statement below the lazy loading under the get_storefront() to print out the list of recommendations and add another print statement to when the recommendation is being stored in save_to_db() after the appending to the batch_list call.  Then compare the results, they should be the same, but the main branch they are not.  The solution has the lists being the same minus the ones that should not be seen because of organizational and other issues)

Please review:
@mannyrivera2010 
@skhtet 
@J-Fid 
@rkenyon1969 
@blynch11p 