### PR TITLE
fix(notifications): Sort notifications by created date

### DIFF
--- a/ozpcenter/api/notification/model_access.py
+++ b/ozpcenter/api/notification/model_access.py
@@ -604,12 +604,12 @@ def get_all_pending_notifications(for_user=False):
         django.db.models.query.QuerySet(Notification): List of system-wide pending notifications
     """
     unexpired_system_notifications = Notification.objects.filter(
-        expires_date__gt=datetime.datetime.now(pytz.utc))
+        expires_date__gt=datetime.datetime.now(pytz.utc)).order_by('-created_date')
 
     if for_user:
         unexpired_system_notifications = unexpired_system_notifications.filter(agency__isnull=True,
                                               listing__isnull=True,
-                                              _peer__isnull=True)
+                                              _peer__isnull=True).order_by('-created_date')
 
     return unexpired_system_notifications
 
@@ -629,7 +629,7 @@ def get_all_expired_notifications():
         django.db.models.query.QuerySet(Notification): List of system-wide pending notifications
     """
     expired_system_notifications = Notification.objects.filter(
-        expires_date__lt=datetime.datetime.now(pytz.utc))
+        expires_date__lt=datetime.datetime.now(pytz.utc)).order_by('-created_date')
     return expired_system_notifications
 
 

--- a/ozpcenter/api/notification/tests/test_api_notification.py
+++ b/ozpcenter/api/notification/tests/test_api_notification.py
@@ -476,11 +476,11 @@ class NotificationApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         notification_list = [['{}-{}-{}'.format(entry['entity_id'], entry['notification_type'], ''.join(entry['message'].split())), entry['expires_date']] for entry in response.data]
-        expected = ['1-listing-Auserhasratedlisting<b>AirMail</b>5stars',
-                    '1-listing-Auserhasratedlisting<b>AirMail</b>3stars',
-                    '1-listing-Auserhasratedlisting<b>AirMail</b>1star',
+        expected = ['1-listing-AirMailupdatenextweek',
                     '1-listing-AirMailupdatenextweek',
-                    '1-listing-AirMailupdatenextweek']
+                    '1-listing-Auserhasratedlisting<b>AirMail</b>1star',
+                    '1-listing-Auserhasratedlisting<b>AirMail</b>3stars',
+                    '1-listing-Auserhasratedlisting<b>AirMail</b>5stars']
 
         self.assertEqual(expected, [entry[0] for entry in notification_list])
 


### PR DESCRIPTION
Fix for active notification bug where notifications weren't being sorted by creation date