### PR TITLE
ES Recommendation Engine added categories to items to look for and increased ratings value to 3.5

### DIFF
--- a/ozpcenter/recommend/recommend.py
+++ b/ozpcenter/recommend/recommend.py
@@ -412,9 +412,6 @@ class ElasticsearchUserBaseRecommender(Recommender):
                 body=query_term
             )
 
-            ratings_items = []
-            ratings_items.append({"listing_id": record[1], "rate": record[2]})
-
             # For each reviewed listing_id in ratings_items get the categories associated with the listing:
             es_cat_query_term = {
                 "_source": ["id", "categories"],
@@ -430,8 +427,6 @@ class ElasticsearchUserBaseRecommender(Recommender):
                 index=settings.ES_INDEX_NAME,
                 body=es_cat_query_term
             )
-            # print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-            # print("CAT SEARCH RESULTS: ", es_cat_search)
 
             # Set category_items array with category id's:
             category_items = []
@@ -440,7 +435,8 @@ class ElasticsearchUserBaseRecommender(Recommender):
             else:
                 logger.debug("== CATEGORY ITEMS MORE THAN 1 ({}) ==".format(es_cat_search['hits']['total']))
 
-            # print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            ratings_items = []
+            ratings_items.append({"listing_id": record[1], "rate": record[2], "listing_categories": category_items})
 
             if es_search_result['hits']['total'] == 0:
                 # If rescord does not exist in Recommendation List, then create it:

--- a/ozpcenter/recommend/recommend.py
+++ b/ozpcenter/recommend/recommend.py
@@ -342,7 +342,10 @@ class ElasticsearchUserBaseRecommender(Recommender):
     friendly_name = 'Elasticsearch User Based Filtering'
     # The weights that are returned by Elasticsearch will be 0.X and hence the reason that we need to multiply
     # by factors of 10 to get reasonable values for ranking.
-    recommendation_weight = 50.0
+    # Making weight of 25 so that results will correlate well with other recommendation engines when combined.
+    # Reasoning: Results of scores are between 0 and 1 with results mainly around 0.0X, thus the recommendation weight
+    #            will mix well with other recommendations and not become too large at the same time.
+    recommendation_weight = 25.0
     MIN_ES_RATING = 3.5  # Minimum rating to have results meet before being recommended for ES Recommender Systems
 
     def initiate(self):


### PR DESCRIPTION
Please Review the changes for the changes that have added categories to the items being recommended.

The Categories are determined by the recommended and bookmarked listings in a user profile and then Elasticsearch uses those items to find users with similar listings in their profiles.  It then ranks the listings based on reviews of greater than 3.5 to return the results.

To test:  (SEE UPDATE AT END)
Run make recommend_es_user
Use bettafish user and a list of listings should come back for the recommended list then review a couple of the apps that are not in the recommended list and give high ratings > 3.  Run make recommend_es_user again
Look at the results and should notice apps from the same category appear.
(Ex. No Jobspot was showing up, so I reviewed Jobspot 1 and Jpbspot 9 and gave a review of 5.  I then reran the make recommend_es_user and it now shows Jobspot apps in my recommended list)

Please review changes that were done to the Elasticsearch User Based Recommendation System:
@mannyrivera2010 
@skhtet 
@blynch11p 
@J-Fid 
@mleeBoeing 

**UPDATED TESTING INFORMATION:**
The following should help document the behavior of how the Elasticsearch recommendation engine should work with the changes that have been done.
First start off with a clean environment by running: make dev
Then run: make recommend_es_user
Start the back-end and front-end with Elasticsearch running and see the recommended apps as follows:
(The first three should be the same, but the remaining ones may be different due to jittering)
Possible Initial list (May be different due to jittering):
- Bread Basket
- Skybox 1
- Location Lister 4
- Location Lister 5
- Location Lister 6
- Location Lister 8
- Air Mail
- Skybox 2
- Skybox 3
- JotSpot 1

Another sample:
- Bread Basket
- Skybox 1
- LocationLister 4
- LocationLister 5
- LocaitonLister 6
- LocationLister 8
- LocationLister 9
- Chart Course
- Air Mail

Then Bookmark the following Apps:
JotSpot 5
JotSpot 6
(Note what categories they are in as well)
LEAVE Web Window Open with current recommendation listings

Stop Backend and run: make recommend_es_user
Start Backend again

On a different window open up Home page site.
Results should look like:
- JotSpot 1
- JotSpot 2
- JotSpot 3
- JotSpot 4
- JotSpot 8
- JotSpot 9-
- LocationLister 1
- LocationLister 2
- LocationLister 5
- LocationLister 7

Another sample:
- JotSpot 1
- JotSpot 2
- JotSpot 3
- JotSpot 8
- JotSpot 9
- LocationLister
- LocationLister 1
- LocationLister 2
- LocationLister 3
- LocationLister 4
(Note the categories that the listings are in and should be related to JotSpot 5 and 6)

The listings should now have items related to the categories that were bookmarked.  Note that if items are reviewed with a ranking of 1-3, then the categories are not included in the ones that are analyzed.