### PR TITLE
Boost Value change from 10 to 2 for ratings for ES Recommendation Engine

### DIFF
--- a/ozpcenter/recommend/recommend.py
+++ b/ozpcenter/recommend/recommend.py
@@ -412,7 +412,7 @@ class ElasticsearchUserBaseRecommender(Recommender):
                                 },
                                 "rate": {
                                     "type": "long",
-                                    "boost": 10
+                                    "boost": 2
                                 },
                                 "listing_categories": {
                                     "type": "long"


### PR DESCRIPTION
Per @skhtet request, I am changing the the boost value from 10 to 2 for the Elasticsearch query.
Please review:
@skhtet 
@mannyrivera2010 
@J-Fid 
@mleeBoeing 

On the development setup may not notice differences since the baseline might drown out the results.  Need to verify with debug statements if results do not show up as expected.  Use bettafish as the user.