### PR TITLE
Recommend optimize - Optimization to have all of the recommendations come out at the same level

### DIFF
--- a/ozpcenter/api/storefront/model_access.py
+++ b/ozpcenter/api/storefront/model_access.py
@@ -381,16 +381,20 @@ def get_recommendation_listing_ids(profile_instance):
     recommended_entry_data = {}
     if target_profile_recommended_entry:
         recommendation_data = target_profile_recommended_entry.recommendation_data
+        print("Recommendation Data initially found: ", recommendation_data)
         if recommendation_data:
             recommended_entry_data = msgpack.unpackb(recommendation_data, encoding='utf-8')
 
     recommendation_combined_dict = {'profile': {}}
 
+    print("Recommended Entry Data: ", recommended_entry_data)
     for recommender_friendly_name in recommended_entry_data:
         recommender_name_data = recommended_entry_data[recommender_friendly_name]
         # print(recommender_name_data)
         recommender_name_weight = recommender_name_data['weight']
         recommender_name_recommendations = recommender_name_data['recommendations']
+        print("Recommender Friendly Name: ", recommender_friendly_name)
+        print("Recommender Data: ", recommender_name_data)
 
         for recommendation_tuple in recommender_name_recommendations:
             current_listing_id = recommendation_tuple[0]
@@ -402,10 +406,12 @@ def get_recommendation_listing_ids(profile_instance):
                 recommendation_combined_dict['profile'][current_listing_id] = current_listing_score * recommender_name_weight
 
     sorted_recommendations_combined_dict = recommend_utils.get_top_n_score(recommendation_combined_dict, 40)
+    print("Sorted Recommendation List: ", sorted_recommendations_combined_dict)
     # sorted_recommendations_combined_dict = {'profile': [[11, 8.5], [112, 8.0], [85, 7.0], [86, 7.0], [87, 7.0],
     #    [88, 7.0], [89, 7.0], [90, 7.0], [81, 6.0], [62, 6.0],
     #    [21, 5.5], [1, 5.0], [113, 5.0], [111, 5.0], [114, 5.0], [64, 4.0], [66, 4.0], [68, 4.0], [70, 4.0], [72, 4.0]]}
     listing_ids_list = [entry[0] for entry in sorted_recommendations_combined_dict['profile']]
+    print("listing_ids_list: ", listing_ids_list)
     return listing_ids_list, recommended_entry_data
 
 

--- a/ozpcenter/api/storefront/model_access.py
+++ b/ozpcenter/api/storefront/model_access.py
@@ -381,20 +381,16 @@ def get_recommendation_listing_ids(profile_instance):
     recommended_entry_data = {}
     if target_profile_recommended_entry:
         recommendation_data = target_profile_recommended_entry.recommendation_data
-        print("Recommendation Data initially found: ", recommendation_data)
         if recommendation_data:
             recommended_entry_data = msgpack.unpackb(recommendation_data, encoding='utf-8')
 
     recommendation_combined_dict = {'profile': {}}
 
-    print("Recommended Entry Data: ", recommended_entry_data)
     for recommender_friendly_name in recommended_entry_data:
         recommender_name_data = recommended_entry_data[recommender_friendly_name]
         # print(recommender_name_data)
         recommender_name_weight = recommender_name_data['weight']
         recommender_name_recommendations = recommender_name_data['recommendations']
-        print("Recommender Friendly Name: ", recommender_friendly_name)
-        print("Recommender Data: ", recommender_name_data)
 
         for recommendation_tuple in recommender_name_recommendations:
             current_listing_id = recommendation_tuple[0]
@@ -406,12 +402,10 @@ def get_recommendation_listing_ids(profile_instance):
                 recommendation_combined_dict['profile'][current_listing_id] = current_listing_score * recommender_name_weight
 
     sorted_recommendations_combined_dict = recommend_utils.get_top_n_score(recommendation_combined_dict, 40)
-    print("Sorted Recommendation List: ", sorted_recommendations_combined_dict)
     # sorted_recommendations_combined_dict = {'profile': [[11, 8.5], [112, 8.0], [85, 7.0], [86, 7.0], [87, 7.0],
     #    [88, 7.0], [89, 7.0], [90, 7.0], [81, 6.0], [62, 6.0],
     #    [21, 5.5], [1, 5.0], [113, 5.0], [111, 5.0], [114, 5.0], [64, 4.0], [66, 4.0], [68, 4.0], [70, 4.0], [72, 4.0]]}
     listing_ids_list = [entry[0] for entry in sorted_recommendations_combined_dict['profile']]
-    print("listing_ids_list: ", listing_ids_list)
     return listing_ids_list, recommended_entry_data
 
 


### PR DESCRIPTION
Please review changes that normalize the results for the recommendations.  This will allow us to have all of the results inline:
@mannyrivera2010 
@skhtet 
@blynch11p 
@rkenyon1969 

Changes were also made during testing for reducing the boost rating from 2 to 1 for rating and also improved the results returned from content filtering.

Here is the how to verify the results:
To Evaluate recommendation normalization (Based on original apps that have been used and will change if new apps are added):

Observe the raw_scores and they should all be in the same range without the other scores and not be too out of the area 

> make dev (Stop the backend after it starts running)
> make recommend
> make run_es
check recommendations returned by going to:
http://(Address of machine):8000/dist/#/home/?%2F%3F%2F%3F=
Login as bettafish user
http://(Address of machine):8001/api/storefront/

Search for “_score” and observe the Apps that are being recommended and the engine that is being used.  Should see a majority of them being “Baseline”

Stop the backend and do the following:
> make recommend_es
> make run_es
check recommendations returned by going to storefront again:
http://<Address of machine>:8000/dist/#/home/?%2F%3F%2F%3F=
If asked to login again, use bettafish as the user
http://(Address of machine):8001/api/storefront/

Search for “_score” and observe the Apps that are being recommended and the engine that is being used.  Should see a mix of results from “Baseline” and “Elasticsearch Content Filtering” with some being combined results

Next go to the AppsMall Center and bookmark “AirMail 5”
Stop the backend and do the following:
> make recommend_es
> make run_es

check recommendations returned by going to storefront again:
http://(Address of machine):8000/dist/#/home/?%2F%3F%2F%3F=
If asked to login again, use bettafish as the user
http://(Address of machine):8001/api/storefront/

Search for “_score” and observe the Apps that are being recommended and the engine that is being used.  Should see a mix of results from “Baseline”, “Elasticsearch Content Filtering” and “Elasticsearch User Based Filtering” with some being combined results.

Next go to the AppsMall Center and bookmark “JotSpot 4”
Stop the backend and do the following:
> make recommend_es
> make run_es
check recommendations returned by going to storefront again:
http://(Address of machine):8000/dist/#/home/?%2F%3F%2F%3F=
If asked to login again, use bettafish as the user
http://(Address of machine):8001/api/storefront/

Search for “_score” and observe the Apps that are being recommended and the engine that is being used.  Should see a mix of results from “Baseline”, “Elasticsearch Content Filtering” and “Elasticsearch User Based Filtering” with more being combined results with more “Elasticsearch Content” and “Elasticsearch User Based” results.
