### PR TITLE
Title priority feature to prefer titles over other values first.

### DIFF
--- a/ozpcenter/api/listing/elasticsearch_util.py
+++ b/ozpcenter/api/listing/elasticsearch_util.py
@@ -674,8 +674,6 @@ def make_search_query_obj(search_param_parser, exclude_agencies=None):
 
     if user_offset:
         search_query['from'] = user_offset
-    print("**********************QUERY IS:")
-    print(search_query)
     return search_query
 
 

--- a/ozpcenter/api/listing/elasticsearch_util.py
+++ b/ozpcenter/api/listing/elasticsearch_util.py
@@ -610,6 +610,14 @@ def make_search_query_obj(search_param_parser, exclude_agencies=None):
             }
         })
 
+        # Search the title first to give it the score it needs and weight to order
+        # the list by title preferance.
+        temp_should.append({
+           "match": {
+              "title": user_string
+           }
+        })
+
         # The reason fuzziness is needed using the sample_data is because if
         # searching for 'ir', the results should bring up 'air mail' listings
         # without it will not bring 'air mail' listings
@@ -666,6 +674,8 @@ def make_search_query_obj(search_param_parser, exclude_agencies=None):
 
     if user_offset:
         search_query['from'] = user_offset
+    print("**********************QUERY IS:")
+    print(search_query)
     return search_query
 
 


### PR DESCRIPTION
The title will be preferred for matching over other items.  The order will be based on the scoring that is returned and may not necessarily be in alphabetical order.

This needs to be confirmed that it resolves ticket number ALMNG-206 before completing the task.  @skhtet please confirm that the issue is resolved with the fix.  Might have to manually enter it in to see the results.

Please review:
@mannyrivera2010 
@skhtet 
@blynch11p 
@rkenyon1969 