### PR TITLE
feat(titlepriority): Prefer Title to appear first with all words matching

### DIFF
--- a/ozpcenter/api/listing/elasticsearch_util.py
+++ b/ozpcenter/api/listing/elasticsearch_util.py
@@ -687,9 +687,13 @@ def make_search_query_obj(search_param_parser, exclude_agencies=None):
         # Search the title first to give it the score it needs and weight to order
         # the list by title preferance.
         temp_should.append({
-           "match": {
-              "title": user_string
-           }
+            "match": {
+                "title": {
+                    "query": user_string,
+                    "operator": "and",
+                    "boost": 10
+                }
+            }
         })
 
         # The reason fuzziness is needed using the sample_data is because if


### PR DESCRIPTION
AMLNG-207
Please review this change that will prefer titles that match all words over just matching partial words first and will boost the results to the highest level when the title matches.  It was tested with lower Boost values and found that at least a 5 was needed to get the behavior desired, thus it was made 10 to make sure that titles matching all of the words appear first in the list.

Please review
@mannyrivera2010 
@skhtet 
@blynch11p 
@rkenyon1969 
@mleeBoeing 
@flesher1 

TO TEST:
First test on main latest by searching for "air mail" without quotes.
Should notice that the Air Mail is not the first one in the list and is the second one.
Note the results that are returned.

Pull the branch
Run backend and search again for "air mail"
Now should see Air Mail as the first one in the list.

Note: Matching of items within other parts of the listing might affect the order as well and hence when testing with other combinations check for partial matches which might influence the overall score of the results returned.