### PR TITLE
feat(activity log): add new review to activity log

### DIFF
--- a/ozpcenter/api/listing/model_access.py
+++ b/ozpcenter/api/listing/model_access.py
@@ -650,6 +650,23 @@ def create_listing_review(username, listing, rating, text=None, review_parent=No
     review = models.Review(listing=listing, author=author, rate=rating, text=text, review_parent=review_parent)
     review.save()
 
+    # add this action to the log
+    change_details = [
+        {
+            'field_name': 'rate',
+            'old_value': None,
+            'new_value': rating
+        },
+        {
+            'field_name': 'text',
+            'old_value': None,
+            'new_value': text
+        }
+    ]
+    listing = review.listing
+    listing = _add_listing_activity(author, listing,
+        models.ListingActivity.REVIEWED, change_details=change_details)
+
     # update this listing's rating
     _update_rating(username, listing)
 

--- a/ozpcenter/models.py
+++ b/ozpcenter/models.py
@@ -1428,6 +1428,7 @@ class ListingActivity(models.Model):
     # a review for a listing has been deleted
     REVIEW_DELETED = 'REVIEW_DELETED'
     PENDING_DELETION = 'PENDING_DELETION'
+    REVIEWED = 'REVIEWED'
 
     ACTION_CHOICES = (
         (CREATED, 'CREATED'),
@@ -1439,6 +1440,7 @@ class ListingActivity(models.Model):
         (ENABLED, 'ENABLED'),
         (DISABLED, 'DISABLED'),
         (DELETED, 'DELETED'),
+        (REVIEWED, 'REVIEWED'),
         (REVIEW_EDITED, 'REVIEW_EDITED'),
         (REVIEW_DELETED, 'REVIEW_DELETED'),
         (PENDING_DELETION, 'PENDING_DELETION')

--- a/tests/ozpcenter_api/test_api_review.py
+++ b/tests/ozpcenter_api/test_api_review.py
@@ -60,6 +60,13 @@ class ListingReviewApiTest(APITestCase):
         new_review = models.Review.objects.get(id=created_id)
         self.assertEqual(created_id, new_review.id)
 
+        # test the listing/<id>/activity endpoint
+        url = '/api/listing/{0!s}/activity/'.format(air_mail_id)
+        response = self.client.get(url, format='json')
+        activiy_actions = [i['action'] for i in response.data]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(models.ListingActivity.REVIEWED in activiy_actions)
+
         # creating a duplicate review should fail
         # http://stackoverflow.com/questions/21458387/transactionmanagementerror-you-cant-execute-queries-until-the-end-of-the-atom
         # try:


### PR DESCRIPTION
Add function call to add new review creations to activity log.
Create test for activity log for new reviews created.

AMLNG-786

**Description**     
As an Admin, I would like to see new listing reviews appear in ListingMngmt>Recent Activity to facilitate Admin notification of posted comments.

**Acceptance Criteria**   
• when a user submits review a summary will appear in ListingMngmt>Recent Activity
• the summary will include a link to the review tab of the reviewed listing
• similar to when a review is deleted

**How to test code**    
Test functionality by pulling https://github.com/aml-development/ozp-center/tree/New_Recent_Activity_entry
After creating a review, there will be an entry in /dist/#/user-management/recent-activity

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

