### PR TITLE
fix(launch popup): show requirements information

### DIFF
--- a/ozpcenter/api/listing/serializers.py
+++ b/ozpcenter/api/listing/serializers.py
@@ -912,6 +912,8 @@ class StorefrontListingSerializer(serializers.HyperlinkedModelSerializer):
                   'feedback',
                   'description_short',
                   'security_marking',
+                  'usage_requirements',
+                  'system_requirements',
                   'launch_url',
                   'large_banner_icon',
                   'banner_icon',

--- a/tests/ozpcenter_api/test_api_storefront.py
+++ b/tests/ozpcenter_api/test_api_storefront.py
@@ -53,12 +53,16 @@ class StorefrontApiTest(APITestCase):
 
         self.assertIn('featured', response.data)
         self.assertTrue(len(response.data['featured']) >= 1)
+        self._check_listing_properties(response.data['featured'])
         self.assertIn('recent', response.data)
         self.assertTrue(len(response.data['recent']) >= 1)
+        self._check_listing_properties(response.data['recent'])
         self.assertIn('most_popular', response.data)
         self.assertTrue(len(response.data['most_popular']) >= 1)
+        self._check_listing_properties(response.data['most_popular'])
         self.assertIn('recommended', response.data)
         self.assertTrue(len(response.data['recommended']) >= 1)
+        self._check_listing_properties(response.data['recommended'], ['_score'])
 
     def test_storefront_authorized_recommended(self):
         url = '/api/storefront/recommended/'
@@ -73,6 +77,7 @@ class StorefrontApiTest(APITestCase):
         self.assertEqual(response.data['most_popular'], [])
         self.assertIn('recommended', response.data)
         self.assertTrue(len(response.data['recommended']) >= 1)
+        self._check_listing_properties(response.data['recommended'], ['_score'])
 
     def test_storefront_authorized_featured(self):
         url = '/api/storefront/featured/'
@@ -81,6 +86,7 @@ class StorefrontApiTest(APITestCase):
         response = self.client.get(url, format='json')
         self.assertIn('featured', response.data)
         self.assertTrue(len(response.data['featured']) >= 1)
+        self._check_listing_properties(response.data['featured'])
         self.assertIn('recent', response.data)
         self.assertEqual(response.data['recent'], [])
         self.assertIn('most_popular', response.data)
@@ -99,6 +105,7 @@ class StorefrontApiTest(APITestCase):
         self.assertEqual(response.data['recent'], [])
         self.assertIn('most_popular', response.data)
         self.assertTrue(len(response.data['most_popular']) >= 1)
+        self._check_listing_properties(response.data['most_popular'])
         self.assertIn('recommended', response.data)
         self.assertEqual(response.data['recommended'], [])
 
@@ -111,6 +118,7 @@ class StorefrontApiTest(APITestCase):
         self.assertEqual(response.data['featured'], [])
         self.assertIn('recent', response.data)
         self.assertTrue(len(response.data['recent']) >= 1)
+        self._check_listing_properties(response.data['recent'])
         self.assertIn('most_popular', response.data)
         self.assertEqual(response.data['most_popular'], [])
         self.assertIn('recommended', response.data)
@@ -120,3 +128,18 @@ class StorefrontApiTest(APITestCase):
         url = '/api/storefront/'
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, 401)
+
+    def _check_listing_properties(self, listings, additional_keys=None):
+        additional_keys = [] if additional_keys is None else additional_keys
+        desired_keys = ['id', 'title', 'agency', 'avg_rate',
+            'total_reviews', 'feedback_score', 'is_private', 'is_bookmarked',
+            'feedback', 'description_short', 'security_marking',
+            'usage_requirements', 'system_requirements', 'launch_url',
+            'large_banner_icon', 'banner_icon', 'unique_name', 'is_enabled']
+        desired_keys += additional_keys
+        desired_keys = sorted(desired_keys)
+
+        for listing in listings:
+            actual_keys = sorted(listing.keys())
+
+            self.assertEqual(desired_keys, actual_keys)

--- a/tests/ozpcenter_api/test_api_storefront.py
+++ b/tests/ozpcenter_api/test_api_storefront.py
@@ -1,6 +1,8 @@
 """
 Tests for storefront endpoints
+TODO: should we test keys of each item in the list of listings for storefront
 """
+
 from django.test import override_settings
 from rest_framework.test import APITestCase
 


### PR DESCRIPTION
AMLNG-798

**Description**     
Pre-req - Define system and usage requirements in an App Listing. In Profile Settings , Enable the option Show Launch Requirements Notice
Go to Homepage
From Thumbnail view, Launch App from thumbnail view

**Acceptance Criteria**   
RESULTS - Sys/Usage requirements pop up displays without the actual system / usage requirements.
EXPECTED RESULTS - Sys/usage requirements from pre-requisites should display on the this pop up.
Open Quick View Modal
Launch App
RESULTS - Sys/usage requirements from the prerequisites display on the pop up as they should.
 
**How to test code**    
Pull amlng798 from ozp-backend
Pull amlng798 from ozp-center

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

