### PR TITLE
feat(listing management): add ability to sort list view

### DIFF
--- a/ozpcenter/api/listing/views.py
+++ b/ozpcenter/api/listing/views.py
@@ -697,7 +697,8 @@ class ListingViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.ListingSerializer
     filter_backends = (filters.SearchFilter, filters.OrderingFilter)
     search_fields = ('title', 'id', 'owners__display_name', 'agency__title', 'agency__short_name',)
-    ordering_fields = ('title', 'id', 'agency__title', 'agency__short_name', 'is_enabled', 'is_featured', 'edited_date', 'security_marking', 'is_private', 'approval_status')
+    ordering_fields = ('title', 'id', 'agency__title', 'agency__short_name', 'is_enabled', 'is_featured',
+        'edited_date', 'security_marking', 'is_private', 'approval_status', 'avg_rate', 'total_votes')
     ordering = ('is_deleted', '-edited_date')
 
     def get_queryset(self):
@@ -705,7 +706,7 @@ class ListingViewSet(viewsets.ModelViewSet):
         # org = self.request.query_params.get('org', None)
         orgs = self.request.query_params.getlist('org', False)
         enabled = self.request.query_params.get('enabled', None)
-        ordering = self.request.query_params.getlist('ordering', ['-edited_date'])
+        ordering = self.request.query_params.get('ordering', None)
         owners_id = self.request.query_params.get('owners_id', None)
         if enabled:
             enabled = enabled.lower()
@@ -713,6 +714,11 @@ class ListingViewSet(viewsets.ModelViewSet):
                 enabled = True
             else:
                 enabled = False
+        if ordering:
+            ordering = [s.strip() for s in ordering.split(',')]
+        else:
+            # always default to last modified for consistency
+            ordering = ['-edited_date']
 
         listings = model_access.get_listings(self.request.user.username)
         if owners_id:

--- a/ozpcenter/api/listing/views.py
+++ b/ozpcenter/api/listing/views.py
@@ -705,7 +705,7 @@ class ListingViewSet(viewsets.ModelViewSet):
         # org = self.request.query_params.get('org', None)
         orgs = self.request.query_params.getlist('org', False)
         enabled = self.request.query_params.get('enabled', None)
-        ordering = self.request.query_params.getlist('ordering', None)
+        ordering = self.request.query_params.getlist('ordering', ['-edited_date'])
         owners_id = self.request.query_params.get('owners_id', None)
         if enabled:
             enabled = enabled.lower()

--- a/ozpcenter/api/listing/views.py
+++ b/ozpcenter/api/listing/views.py
@@ -698,7 +698,8 @@ class ListingViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.SearchFilter, filters.OrderingFilter)
     search_fields = ('title', 'id', 'owners__display_name', 'agency__title', 'agency__short_name',)
     ordering_fields = ('id', 'agency__title', 'agency__short_name', 'is_enabled', 'is_featured',
-        'edited_date', 'security_marking', 'is_private', 'approval_status', 'avg_rate', 'total_votes')
+        'edited_date', 'security_marking', 'is_private', 'approval_status', 'approved_date',
+        'avg_rate', 'total_votes')
     case_insensitive_ordering_fields = ('title',)
     ordering = ('is_deleted', '-edited_date')
 

--- a/tests/ozpcenter_api/test_api_listing.py
+++ b/tests/ozpcenter_api/test_api_listing.py
@@ -1053,3 +1053,52 @@ class ListingApiTest(APITestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(response.data['feedback'], 0)
         self.assertEqual(response.data['feedback_score'], 0)
+
+    def test_listing_ordering(self):
+        """
+        betafish user
+        """
+        user = generic_model_access.get_profile('bettafish').user
+        self.client.force_authenticate(user=user)
+
+        # Last Modified
+        url = '/api/listing/?ordering=-edited_date'
+        response = self.client.get(url, format='json')
+        results = [x for x in response.data if hasattr(x, 'edited_date')]
+        sorted_results = sorted(results, key=lambda x: x['edited_date'], reverse=True)
+        self.assertEqual(results, sorted_results)
+
+        # Newest
+        url = '/api/listing/?ordering=-approved_date'
+        response = self.client.get(url, format='json')
+        results = [x for x in response.data if hasattr(x, 'approved_date')]
+        sorted_results = sorted(results, key=lambda x: x['approved_date'], reverse=True)
+        self.assertEqual(results, sorted_results)
+
+        # Title: A to Z
+        url = '/api/listing/?ordering=title'
+        response = self.client.get(url, format='json')
+        results = [x for x in response.data if hasattr(x, 'title')]
+        sorted_results = sorted(results, key=lambda x: x['title'])
+        self.assertEqual(results, sorted_results)
+
+        # Title: Z to A
+        url = '/api/listing/?ordering=-title'
+        response = self.client.get(url, format='json')
+        results = [x for x in response.data if hasattr(x, 'title')]
+        sorted_results = sorted(results, key=lambda x: x['title'], reverse=True)
+        self.assertEqual(results, sorted_results)
+
+        # Rating: High to Low
+        url = '/api/listing/?ordering=avg_rate,total_votes'
+        response = self.client.get(url, format='json')
+        results = [x for x in response.data if hasattr(x, 'avg_rate') and hasattr(x, 'total_votes')]
+        sorted_results = sorted(results, key=lambda x: (x['avg_rate'], x['total_votes']))
+        self.assertEqual(results, sorted_results)
+
+        # Rating: Low to High
+        url = '/api/listing/?ordering=-avg_rate,-total_votes'
+        response = self.client.get(url, format='json')
+        results = [x for x in response.data if hasattr(x, 'avg_rate') and hasattr(x, 'total_votes')]
+        sorted_results = sorted(results, key=lambda x: (x['avg_rate'], x['total_votes']), reverse=True)
+        self.assertEqual(results, sorted_results)


### PR DESCRIPTION
AMLNG-858

**Description**     
As a user, I would like all Listing Management tabs to have sort order dropdown option to reorder results and the default sort order to be last modified.

**Acceptance Criteria**   
- when a user clicks on sub tab all results will have the same sort order
- sort order will be last modified
- each tab will have sort order dropdown option to reorder results

For now, the sort options are Last Modified, Newest, Title: A to Z, Title: Z to A, Rating: Low to High, Rating: High to Low, Status.  If no sort option is selected, the backend sort defaults to last modified.
 
**How to test code**    
Pull `listing_default_sort` from ozp-backend
Pull `listing_mgmt_sortable_grid` from ozp-center

Go to Listing Management
Verify Acceptance Criteria on the list view of both the All Center Listings and My Listings tabs

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

