### PR TITLE
fix(library): Add Order to Library Creation

### DIFF
--- a/ozpcenter/api/library/model_access.py
+++ b/ozpcenter/api/library/model_access.py
@@ -93,6 +93,11 @@ def create_self_user_library_entry(username, listing_id, folder_name=None, posit
     owner = generic_model_access.get_profile(username)
     listing = listing_model_access.get_listing_by_id(username, listing_id)
 
+    library = get_self_application_library(username)
+
+    if library:
+        position = library.reverse()[0].position + 1
+
     if not listing or not owner:
         raise Exception('Listing or user not found')
 

--- a/tests/ozpcenter_model_access/test_library.py
+++ b/tests/ozpcenter_model_access/test_library.py
@@ -69,6 +69,10 @@ class LibraryTest(TestCase):
         results = model_access.create_self_user_library_entry('bigbrother', 1, position=3)
         self.assertIsNotNone(results)
 
+        model_access.create_self_user_library_entry('bigbrother', 33)
+        results = model_access.get_self_application_library('bigbrother')
+        self.assertEquals(results.reverse()[0].listing.id, 33)
+
     def test_create_batch_library_entries(self):
         data = [
             {


### PR DESCRIPTION
Fix for when listing is added to the library, it is inserted last into the list.
Adds tests to check for correct ordering of listings added to library.

Closes #AMLNG-699

AMLNG-699

**Description**     
HUD Screen should display apps in a consistent order
STR-
pre-req - Create 2 folders in HUD containing a couple bookmarked items.  Leave a few bookmarked items not in folders.
NOTE The HUD screen reflects the folders first and the remaining bookmarked listings thereafter
From Center, Bookmark a new App listing or two
Go to HUD Screen
RESULTS - The HUD Screen displays a folder first, then places the newly added bookmarked items next then the remaining folder(s), with the remaining bookmarked apps last.
EXPECTED RESULTS - The HUD screen should display folders first then remaining bookmarked app listings.

**Acceptance Criteria**   
Because the user can reorder the listings in any order they would like, modifying the location where new bookmarks are inserted is the best solution. 
New bookmarks should be inserted at the end of the listings that are bookmarked, regaurdless of the order the other listings are in. (currently, newly bookmarked listings will always appear second in HUD)
 
**How to test code**    
Pull this branch. 
Open center. 
Add a bookmark. 
Open hud. 
Verify the listing is last in the list of bookmarks. 

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

