### PR TITLE
fix(listing api): use org short name instead of title for listing filter

### DIFF
--- a/ozpcenter/api/listing/views.py
+++ b/ozpcenter/api/listing/views.py
@@ -728,7 +728,7 @@ class ListingViewSet(viewsets.ModelViewSet):
         if approval_status:
             listings = listings.filter(approval_status=approval_status)
         if orgs:
-            listings = listings.filter(agency__title__in=orgs)
+            listings = listings.filter(agency__short_name__in=orgs)
         if enabled is not None:
             listings = listings.filter(is_enabled=enabled)
         # have to handle this case manually because the ordering includes an app multiple times

--- a/tests/ozpcenter_api/test_api_listing.py
+++ b/tests/ozpcenter_api/test_api_listing.py
@@ -764,7 +764,7 @@ class ListingApiTest(APITestCase):
         test_get_listings_with_query_params
         Supported query params: org (agency title), approval_status, enabled
         """
-        url = '/api/listing/?approval_status=APPROVED&org=Ministry of Truth&enabled=true'
+        url = '/api/listing/?approval_status=APPROVED&org=Minitrue&enabled=true'
 
         user = generic_model_access.get_profile('julia').user
         self.client.force_authenticate(user=user)
@@ -778,7 +778,7 @@ class ListingApiTest(APITestCase):
         """
         test_get_listings_with_query_params
         """
-        url = '/api/listing/?approval_status=APPROVED&org=Ministry of Truth&enabled=true&owners_id=4'
+        url = '/api/listing/?approval_status=APPROVED&org=Minitrue&enabled=true&owners_id=4'
 
         user = generic_model_access.get_profile('julia').user
         self.client.force_authenticate(user=user)


### PR DESCRIPTION
AMLNG-801

**Description**     
When I look at an org's listing, the URL contains the organization's title.  Instead, it should use the organization's short name to prevent spaces in the URL.

**Acceptance Criteria**   
Log in as an Org Steward (ie julia)
Go to Listing Management
Select a tab corresponding to an organization

1) Ensure the URL contains the org's short name instead of the title
2) Ensure the listings are filtered by org appropriately and the counts are correct (both table and grid views).  Test sidebar filters too.
3) Ensure that getting to the tab automatically (ie via the Recent Activity Sidebar filters) follows 1-2 as well.

Manually change the URL as follows:

4) Changing the URL from org short name to org title gives an unauthorized alert message and redirects to the Center homepage.
5) Trying to access an org that the logged in user doesn't have permission to see also is unauthorized
6) Entering "garbage" or blank input also is unauthorized.  In the case of blank input, it simply redirects.
 
**How to test code**    
Pull `org_listing_shortname` from `ozp-backend`   
Pull `org_listing_shortname` from `ozp-center`   

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

