### PR TITLE
refactor(es): listing change

### DIFF
--- a/ozp/urls.py
+++ b/ozp/urls.py
@@ -1,17 +1,8 @@
-"""ozp URL Configuration
+"""
+Ozp URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.8/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
+    https://docs.djangoproject.com/en/1.11/topics/http/urls/
 """
 from django.conf import settings
 from django.conf.urls import include, url
@@ -32,7 +23,7 @@ urlpatterns = [
 ]
 urlpatterns = urlpatterns + apipatterns
 
-# in debug, serve the media and static resources with the django web server
-# https://docs.djangoproject.com/en/1.8/howto/static-files/#serving-static-files-during-development
+# In debug mode, serve the media and static resources with the django web server
+# https://docs.djangoproject.com/en/1.11/howto/static-files/#serving-static-files-during-development
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/ozpcenter/api/agency/urls.py
+++ b/ozpcenter/api/agency/urls.py
@@ -2,16 +2,13 @@
 Agency Urls
 """
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_nested import routers
 
 import ozpcenter.api.agency.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
 router = routers.DefaultRouter()
-
 router.register(r'agency', views.AgencyViewSet)
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
 ]

--- a/ozpcenter/api/category/urls.py
+++ b/ozpcenter/api/category/urls.py
@@ -2,16 +2,13 @@
 Category URLs
 """
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_nested import routers
 
 import ozpcenter.api.category.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
-
+router = routers.SimpleRouter()
 router.register(r'category', views.CategoryViewSet)
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
 ]

--- a/ozpcenter/api/contact_type/urls.py
+++ b/ozpcenter/api/contact_type/urls.py
@@ -2,17 +2,15 @@
 Contact Types URLs
 """
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_nested import routers
 
 import ozpcenter.api.contact_type.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
+router = routers.SimpleRouter()
 
 router.register(r'contact_type', views.ContactTypeViewSet)
 router.register(r'contact', views.ContactViewSet)
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
 ]

--- a/ozpcenter/api/image/urls.py
+++ b/ozpcenter/api/image/urls.py
@@ -2,17 +2,15 @@
 Image URLs
 """
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_nested import routers
 
 import ozpcenter.api.image.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
+router = routers.SimpleRouter()
 
 router.register(r'image', views.ImageViewSet, base_name='image')
 router.register(r'imagetype', views.ImageTypeViewSet, base_name='imagetype')
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
 ]

--- a/ozpcenter/api/intent/urls.py
+++ b/ozpcenter/api/intent/urls.py
@@ -2,16 +2,13 @@
 Intent URLs
 """
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_nested import routers
 
 import ozpcenter.api.intent.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
-
+router = routers.SimpleRouter()
 router.register(r'intent', views.IntentViewSet)
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
 ]

--- a/ozpcenter/api/library/urls.py
+++ b/ozpcenter/api/library/urls.py
@@ -2,17 +2,14 @@
 Library URLs
 """
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_nested import routers
 
 import ozpcenter.api.library.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
-
+router = routers.SimpleRouter()
 router.register(r'library', views.LibraryViewSet)
 router.register(r'self/library', views.UserLibraryViewSet, base_name='applicationlibraryentry')
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
 ]

--- a/ozpcenter/api/listing/observers.py
+++ b/ozpcenter/api/listing/observers.py
@@ -5,13 +5,26 @@ import logging
 import datetime
 import pytz
 
+from rest_framework import serializers
+
+
+from django.conf import settings
 from ozpcenter import models
 from ozpcenter.pubsub import Observer
 from ozpcenter.models import Notification
 import ozpcenter.api.notification.model_access as notification_model_access
+from ozpcenter.api.listing import elasticsearch_util
 
 
 logger = logging.getLogger('ozp-center.' + str(__name__))
+
+
+class ReadOnlyListingSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.Listing
+        depth = 2
+        fields = '__all__'
 
 
 class ListingObserver(Observer):
@@ -249,6 +262,12 @@ class ListingObserver(Observer):
                                                           message=message,
                                                           listing=listing,
                                                           group_target=Notification.USER)
+
+        if settings.ES_ENABLED is True:
+            serializer = ReadOnlyListingSerializer(listing)
+            record = serializer.data  # TODO Find a faster way to serialize data, makes test take a long time to complete
+
+            elasticsearch_util.update_es_listing(record['id'], record, None)
 
     def listing_review_created(self, listing=None, profile=None, rating=None, text=None):
         """

--- a/ozpcenter/api/listing/urls.py
+++ b/ozpcenter/api/listing/urls.py
@@ -35,7 +35,6 @@ router.register(r'listingtype', views.ListingTypeViewSet)
 router.register(r'screenshot', views.ScreenshotViewSet)
 router.register(r'tag', views.TagViewSet)
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
     url(r'^', include(nested_router.urls)),

--- a/ozpcenter/api/notification/urls.py
+++ b/ozpcenter/api/notification/urls.py
@@ -2,17 +2,14 @@
 Notifications URLs
 """
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_nested import routers
 
 import ozpcenter.api.notification.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
-
+router = routers.SimpleRouter()
 router.register(r'notification', views.NotificationViewSet, base_name='notification')
 router.register(r'self/notification', views.UserNotificationViewSet, base_name='notification')
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
     url(r'^notifications/pending/$', views.PendingNotificationView.as_view()),

--- a/ozpcenter/api/profile/urls.py
+++ b/ozpcenter/api/profile/urls.py
@@ -2,15 +2,11 @@
 Profile URLs
 """
 from django.conf.urls import url, include
-# from rest_framework import routers
-# use drf-nested-routers extension
 from rest_framework_nested import routers
 
 import ozpcenter.api.profile.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
 router = routers.SimpleRouter()
-
 router.register(r'profile', views.ProfileViewSet, base_name='profile')
 router.register(r'user', views.UserViewSet)
 router.register(r'group', views.GroupViewSet)
@@ -18,8 +14,6 @@ router.register(r'group', views.GroupViewSet)
 profile_router = routers.NestedSimpleRouter(router, r'profile', lookup='profile')
 profile_router.register(r'listing', views.ProfileListingViewSet, base_name='listing')
 
-
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
     url(r'^', include(profile_router.urls)),

--- a/ozpcenter/api/storefront/urls.py
+++ b/ozpcenter/api/storefront/urls.py
@@ -2,12 +2,10 @@
 Storefront and Metadata URLs
 """
 from django.conf.urls import url, include
-
 from rest_framework_nested import routers
 
 import ozpcenter.api.storefront.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
 router = routers.SimpleRouter()
 router.register(r'storefront', views.StorefrontViewSet, base_name='storefront')
 

--- a/ozpcenter/api/subscription/urls.py
+++ b/ozpcenter/api/subscription/urls.py
@@ -2,17 +2,14 @@
 Notifications URLs
 """
 from django.conf.urls import url, include
-from rest_framework import routers
+from rest_framework_nested import routers
 
 import ozpcenter.api.subscription.views as views
 
-# Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
-
+router = routers.SimpleRouter()
 router.register(r'subscription', views.SubscriptionViewSet, base_name='subscription')
 router.register(r'self/subscription', views.UserSubscriptionViewSet, base_name='self_subscription')
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'^', include(router.urls)),
 ]

--- a/ozpcenter/models.py
+++ b/ozpcenter/models.py
@@ -1212,20 +1212,6 @@ class Listing(models.Model):
         super(Listing, self).save(*args, **kwargs)
         current_listing_id = self.pk
 
-        if settings.ES_ENABLED is True:
-            serializer = ReadOnlyListingSerializer(self)
-            record = serializer.data  # TODO Find a faster way to serialize data, makes test take a long time to complete
-
-            elasticsearch_util.update_es_listing(current_listing_id, record, is_new)
-
-
-class ReadOnlyListingSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Listing
-        depth = 2
-        fields = '__all__'
-
 
 @receiver(post_save, sender=Listing)
 def post_save_listing(sender, instance, created, **kwargs):

--- a/ozpcenter/urls.py
+++ b/ozpcenter/urls.py
@@ -1,12 +1,10 @@
 """
 URLs for all resources - will be placed under /api route by the project level
-urls.py
 """
 from django.conf.urls import url, include
 
 from ozpcenter import views
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'', include('ozpcenter.api.agency.urls')),
     url(r'', include('ozpcenter.api.category.urls')),

--- a/ozpiwc/api/data/urls.py
+++ b/ozpiwc/api/data/urls.py
@@ -1,20 +1,13 @@
 """
-urls
+ozpiwc data
 """
 from django.conf.urls import url, include
+from rest_framework_nested import routers
 
 import ozpiwc.api.data.views as views
 
-from rest_framework_nested import routers
-
 router = routers.SimpleRouter()
-router.register(r'self/data', views.DataApiViewSet, base_name='intent_list_view')
-
-# url(r'^self/data/$', views.DataApiView),
-# # this will capture things like food/pizza/cheese. In the view, the key
-# # will be modified such that it always starts with a / and never ends
-# # with one
-# url(r'^self/data/(?P<key>[a-zA-Z0-9\-/]+)$', views.DataApiView)
+router.register(r'self/data', views.DataApiViewSet, base_name='data_list_view')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/ozpiwc/api/intent/urls.py
+++ b/ozpiwc/api/intent/urls.py
@@ -1,8 +1,10 @@
+"""
+urls
+"""
 from django.conf.urls import url, include
+from rest_framework_nested import routers
 
 import ozpiwc.api.intent.views as views
-
-from rest_framework_nested import routers
 
 router = routers.SimpleRouter()
 router.register(r'self/intent', views.IntentListViewSet, base_name='intent_list_view')

--- a/ozpiwc/api/system/urls.py
+++ b/ozpiwc/api/system/urls.py
@@ -1,8 +1,10 @@
+"""
+urls
+"""
 from django.conf.urls import url, include
+from rest_framework_nested import routers
 
 import ozpiwc.api.system.views as views
-
-from rest_framework_nested import routers
 
 router = routers.SimpleRouter()
 router.register(r'self/application', views.ApplicationViewSet, base_name='application_view')

--- a/ozpiwc/urls.py
+++ b/ozpiwc/urls.py
@@ -1,18 +1,15 @@
 """
-URLs for all resources - will be placed under /iwc-api route by the project
-level urls.py
+URLs for all resources - will be placed under /iwc-api route by the project level urls.py
 """
 from django.conf.urls import url, include
+from rest_framework_nested import routers
 
 import ozpiwc.views as views
-
-from rest_framework_nested import routers
 
 router = routers.SimpleRouter()
 router.register(r'', views.RootApiViewSet, base_name='root_api')
 router.register(r'self', views.UserViewSet, base_name='user_api')
 
-# Wire up our API using automatic URL routing.
 urlpatterns = [
     url(r'', include('ozpiwc.api.data.urls')),
     url(r'', include('ozpiwc.api.intent.urls')),

--- a/performance_testing/listing_update.py
+++ b/performance_testing/listing_update.py
@@ -1,0 +1,87 @@
+import json
+import uuid
+import os
+from timeit import default_timer as timer
+
+from multiprocessing import Pool, TimeoutError, Process, current_process
+
+
+import requests
+
+
+class ProcessResponse(object):
+
+    def __init__(self, data=None):
+        self.data = data or {}
+
+
+
+URL='http://127.0.0.1:8001/'
+AUTH_TUPLE=('bigbrother', 'password')
+
+def update_listing(input_id):
+    proc_name = os.getpid()
+    currrent_url = '{}api/listing/{}/'.format(URL, input_id)
+    listing_data_request = requests.get(currrent_url, auth=AUTH_TUPLE)
+    listing_data =  listing_data_request.json()
+    print('process: {} , currrent_url:{}, get_status_code:{}'.format(proc_name, currrent_url, listing_data_request.status_code))
+
+    uuid_string = str(uuid.uuid1())
+
+    if "=" in listing_data['title']:
+        param, value = listing_data['title'].split("=",1)
+        new_title = '{}={}'.format(param, uuid_string)
+    else:
+        new_title = '{}={}'.format(listing_data['title'], uuid_string)
+
+    listing_data['title']=new_title
+
+    headers = {'Content-Type': 'application/json'}
+
+    start = timer()
+    listing_post_request = requests.put(currrent_url, data=json.dumps(listing_data, indent=2), auth=AUTH_TUPLE, headers=headers)
+    end = timer()
+
+    if listing_post_request.status_code == 200:
+        print(listing_post_request.json()['title'])
+        # print(json.dumps(listing_post_request.json(), indent=2))
+    else:
+        print(listing_post_request.text)
+        return 0
+
+    return ProcessResponse(data={'time_to_post': (end-start)})
+
+
+if __name__ == '__main__':
+    proc_name = os.getpid()
+
+    print('Root PID:{}'.format(proc_name))
+
+
+    pool = Pool(processes=30)
+
+    results = []
+    for n in range(1,10):
+        for i in range(1, 150):
+            results.append(pool.apply_async(update_listing, (i,)))
+
+    # Wait till all tasks in pool are finished
+    pool.close()
+    pool.join()
+
+    times = []
+
+    for result_future in results:
+        process_response = result_future.get()
+        times.append(process_response.data['time_to_post'])
+
+
+    print('Performance Testing for updating listing')
+
+    # print('==Times for each call')
+    #
+    # for i in times:
+    #     print('\t{}'.format(i))
+
+    print('==Average: {}'.format(sum(times)/len(times)))
+    print('==Len: {}'.format(len(times)))


### PR DESCRIPTION
AMLOS-532

**Description**     
Make Elasticsearch Updates more efficient for Listing Modifications

Right now every time a listing gets updated it calls Elasticsearch multiple times via the Model Save Hook.  Have it so that it only calls elasticsearch once for each listing modification via the Observer Listing Hook (only gets called once)

**Acceptance Criteria**   
Code to make Elasticsearch Updates more efficient for Listing Modifications has been Refactor. 
 
**How to test code**    
```
make test_parallel
```

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

