### PR TITLE
fix(library): fix for import_bookmarks

### DIFF
--- a/ozpcenter/api/library/model_access.py
+++ b/ozpcenter/api/library/model_access.py
@@ -259,6 +259,10 @@ def import_bookmarks(current_username, peer_bookmark_notification_id):
 
     # TODO Validate Folder Name
 
+    for entry in models.ApplicationLibraryEntry.objects.for_user(current_username):
+        if entry.folder == peer_folder_name:
+            peer_bookmark_list = [x for x in peer_bookmark_list if x != entry.listing.id]
+
     if errors:
         return errors, None
 


### PR DESCRIPTION
Fixes issue where the add listing API will add multiple of the same listing to existing folder.
This has become more apparent due to the new undelete feature.

Closes# AMLNG-887

**Description**     
If a user has a bookmark folder (Animals) and goes to the URL to add/share a bookmark folder of the same name, with the same bookmarks, those bookmarks are duplicated, rather than just adding new ones. The duplicates are unnecessary, and can cause issues with page reloading.

**Acceptance Criteria**   
A shared bookmark folder link will not duplicate bookmarks the user already has in a folder of the same name.
 
**How to test code**    
Pull this branch.
Go into a folder and send a share notification to another user.
Log in as another user and clicking the button in the share notification.
Delete a listing from the folder and redo the previous steps, the folder should be back to the way it was.

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

