### PR TITLE
fix(notification): listing modification notification

### DIFF
--- a/ozpcenter/api/listing/observers.py
+++ b/ozpcenter/api/listing/observers.py
@@ -227,6 +227,7 @@ class ListingObserver(Observer):
                         'screenshots',
                         'security_marking',
                         'is_featured',
+                        'owners',
                         'contacts']
 
         changes = []


### PR DESCRIPTION
This removes the notification for users when a listing's owners
are modified.

Closes #AMLOS-450

**Description**     
As a user, I do not need to receive a notification when a listing owner change is made

**Acceptance Criteria**   
-  review recipients of notification of listing owner change 
-  User who bookmarked listing does not receive notification when if listing owner change
 
**How to test code**    
Pull this repo. 
Log in as bigbrother and johnson.
As johnson bookmark  any listing.
As bigbrother, open that listing and change the title and add an owner. 
Check that johnson receives a notification about a title change but not an owner change.

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

