### PR TITLE
feat(listing): require feedback when pending a listing for deletion

### DIFF
--- a/ozpcenter/api/listing/model_access.py
+++ b/ozpcenter/api/listing/model_access.py
@@ -355,6 +355,18 @@ def get_rejection_listings(username):
     return activities
 
 
+def get_pending_deletion_listings(username):
+    """
+    Get Pending Deletion Listings for a user
+
+    Args:
+        username (str): username for user
+    """
+    activities = models.ListingActivity.objects.for_user(username).filter(
+        action=models.ListingActivity.PENDING_DELETION)
+    return activities
+
+
 def _add_listing_activity(author, listing, action, change_details=None,
                           description=None):
     """
@@ -455,7 +467,7 @@ def submit_listing(author, listing):
     return listing
 
 
-def pending_delete_listing(author, listing):
+def pending_delete_listing(author, listing, pending_description):
     """
     Submit a listing for Deletion
 
@@ -467,8 +479,10 @@ def pending_delete_listing(author, listing):
         listing
     """
     # TODO: check that all required fields are set
-    listing = _add_listing_activity(author, listing, models.ListingActivity.PENDING_DELETION)
+    print(pending_description)
+    listing = _add_listing_activity(author, listing, models.ListingActivity.PENDING_DELETION, description=pending_description)
     listing.approval_status = models.Listing.PENDING_DELETION
+    listing.is_enabled = False
     listing.edited_date = utils.get_now_utc()
     listing.save()
     return listing

--- a/ozpcenter/api/listing/serializers.py
+++ b/ozpcenter/api/listing/serializers.py
@@ -538,7 +538,9 @@ def update_listing(serializer_instance, instance, validated_data):
         if s == models.Listing.PENDING:
             model_access.submit_listing(user, instance)
         if s == models.Listing.PENDING_DELETION:
-            model_access.pending_delete_listing(user, instance)
+            # pending deletion should be handled through ListingPendingDeletionViewSet
+            # keeping this here for now for backwards compatibility
+            model_access.pending_delete_listing(user, instance, 'Unknown reason')
         if s == models.Listing.APPROVED_ORG:
             model_access.approve_listing_by_org_steward(user, instance)
         if s == models.Listing.APPROVED:

--- a/ozpcenter/api/listing/urls.py
+++ b/ozpcenter/api/listing/urls.py
@@ -29,6 +29,7 @@ nested_router.register(r'feedback', views.RecommendationFeedbackViewSet, base_na
 nested_router.register(r'review', views.ReviewViewSet, base_name='review')
 nested_router.register(r'activity', views.ListingActivityViewSet, base_name='activity')
 nested_router.register(r'rejection', views.ListingRejectionViewSet, base_name='rejection')
+nested_router.register(r'pendingdeletion', views.ListingPendingDeletionViewSet, base_name='pendingdeletion')
 # TODO: nest these
 
 router.register(r'listingtype', views.ListingTypeViewSet)

--- a/tests/ozpcenter_model_access/test_listing.py
+++ b/tests/ozpcenter_model_access/test_listing.py
@@ -145,6 +145,22 @@ class ListingTest(TestCase):
         approved_org_activity = listing_activities[0]
         self.assertEqual(approved_org_activity.author.user.username, username)
 
+    def test_pending_delete_listing(self):
+        steward = generic_model_access.get_profile('wsmith')
+        username = steward.user.username
+        air_mail = models.Listing.objects.for_user(username).get(title='Air Mail')
+
+        description = 'this app needs to be deleted'
+        model_access.pending_delete_listing(steward, air_mail, description)
+
+        air_mail = models.Listing.objects.for_user(username).get(title='Air Mail')
+        self.assertEqual(air_mail.last_activity.action, models.ListingActivity.PENDING_DELETION)
+
+        listing_activities = air_mail.listing_activities.filter(action=models.ListingActivity.PENDING_DELETION)
+        rejected_activity = listing_activities[0]
+        self.assertEqual(rejected_activity.author.user.username, username)
+        self.assertEqual(rejected_activity.description, description)
+
     def test_reject_listing(self):
         steward = generic_model_access.get_profile('wsmith')
         username = steward.user.username


### PR DESCRIPTION
AMLOS-449

**Description**     
As the administrator, I would like to capture the reason for deleting a listing by requiring the user to submit reason during the deletion process.

**Acceptance Criteria**   
1. include feedback form in the deletion process
2. require the user to provide feedback in order to complete the process

Log in as jones
Go to Listing Management > My Listings
Pend a listing for deletion.  Ensure that you are forced to enter a reason.

Log in as bigbrother
Go to the Administration tab of the listing.  Ensure you see the reason set by jones.
Go to Listing Management > Recent Activity.  Ensure you see the reason set by jones.

**How to test code**    
Checkout `pending_deletion_feedback` from `ozp-center`
Checkout `pending_deletion_feedback` from `ozp-backend`

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

