### PR TITLE
Pending deletion notification updates

### DIFF
--- a/ozpcenter/api/listing/observers.py
+++ b/ozpcenter/api/listing/observers.py
@@ -63,6 +63,7 @@ class ListingObserver(Observer):
 
         AMLNG-170 - As an Owner I want to receive notice of whether my deletion request has been approved or rejected
         AMLNG-173 - As an Admin I want notification if an owner has cancelled an app that was pending deletion
+        AMLOS-490 - As an Org Steward or Admin, I want to receive a notification when a listing is submitted to pending deletion
 
         AMLNG-380 - As a user, I want to receive notification when a Listing is added to a subscribed category
         AMLNG-392 - As a user, I want to receive notification when a Listing is added to a subscribed tag
@@ -95,15 +96,24 @@ class ListingObserver(Observer):
 
         # AMLNG-173 - PendingDeletionCancellation
         if profile in listing.owners.all():  # Check to see if current profile is owner of listing
-            if (old_approval_status == models.Listing.PENDING_DELETION and
-                    new_approval_status == models.Listing.PENDING):
-                message = 'A Listing Owner cancelled the deletion of the <b>{}</b> listing'.format(listing.title)
+            if (new_approval_status == models.Listing.PENDING_DELETION):
+                message = 'The <b>{}</b> listing was submitted for deletion by its owner'.format(listing.title)
                 notification_model_access.create_notification(author_username=username,
                                                               expires_date=now_plus_month,
                                                               message=message,
                                                               listing=listing,
                                                               group_target=Notification.ORG_STEWARD,
-                                                              notification_type='PendingDeletionCancellationNotification')
+                                                              notification_type='PendingDeletionToStewardNotification')
+
+            if (old_approval_status == models.Listing.PENDING_DELETION and
+                    new_approval_status == models.Listing.PENDING):
+                message = 'A Listing Owner cancelled the deletion of the <b>{}</b> listing. This listing is now awaiting organizational approval'.format(listing.title)
+                notification_model_access.create_notification(author_username=username,
+                                                              expires_date=now_plus_month,
+                                                              message=message,
+                                                              listing=listing,
+                                                              group_target=Notification.ORG_STEWARD,
+                                                              notification_type='PendingDeletionToStewardNotification')
 
         # AMLNG-170 - PendingDeletionRequest
         elif profile.highest_role() in ['APPS_MALL_STEWARD', 'ORG_STEWARD']:
@@ -116,7 +126,7 @@ class ListingObserver(Observer):
                                                               message=message,
                                                               listing=listing,
                                                               group_target=Notification.USER,
-                                                              notification_type='PendingDeletionRequestNotification')
+                                                              notification_type='PendingDeletionApprovedNotification')
 
             if (old_approval_status == models.Listing.PENDING_DELETION and
                     new_approval_status == models.Listing.PENDING):
@@ -127,7 +137,7 @@ class ListingObserver(Observer):
                                                               message=message,
                                                               listing=listing,
                                                               group_target=Notification.USER,
-                                                              notification_type='PendingDeletionRequestNotification')
+                                                              notification_type='PendingDeletionToOwnerNotification')
 
             if (old_approval_status == models.Listing.PENDING_DELETION and
                     new_approval_status == models.Listing.REJECTED):
@@ -138,7 +148,7 @@ class ListingObserver(Observer):
                                                               message=message,
                                                               listing=listing,
                                                               group_target=Notification.USER,
-                                                              notification_type='PendingDeletionRequestNotification')
+                                                              notification_type='PendingDeletionToOwnerNotification')
 
     def listing_categories_changed(self, listing=None, profile=None, old_categories=None, new_categories=None):
         """

--- a/ozpcenter/api/notification/model_access.py
+++ b/ozpcenter/api/notification/model_access.py
@@ -181,12 +181,16 @@ def create_notification(author_username=None,
         notification_instance = notifications.ListingOwnerNotification()
         notification_instance.set_sender_and_entity(author_username, listing)
 
-    elif notification_type == 'PendingDeletionRequestNotification':
-        notification_instance = notifications.PendingDeletionRequestNotification()
+    elif notification_type == 'PendingDeletionToOwnerNotification':
+        notification_instance = notifications.PendingDeletionToOwnerNotification()
         notification_instance.set_sender_and_entity(author_username, listing)
 
-    elif notification_type == 'PendingDeletionCancellationNotification':
-        notification_instance = notifications.PendingDeletionCancellationNotification()
+    elif notification_type == 'PendingDeletionToStewardNotification':
+        notification_instance = notifications.PendingDeletionToStewardNotification()
+        notification_instance.set_sender_and_entity(author_username, listing)
+
+    elif notification_type == 'PendingDeletionApprovedNotification':
+        notification_instance = notifications.PendingDeletionApprovedNotification()
         notification_instance.set_sender_and_entity(author_username, listing)
 
     elif notification_type == 'CategorySubscriptionNotification':

--- a/ozpcenter/models.py
+++ b/ozpcenter/models.py
@@ -852,8 +852,9 @@ class Profile(models.Model):
     # email_notification_flag: True = Send Emails out for notification
     email_notification_flag = models.BooleanField(default=True)
     # listing_notification_flag will disable/enable:
-    #   ListingSubmissionNotification, PendingDeletionCancellationNotification, PendingDeletionRequestNotification,
-    #  ListingPrivateStatusNotification, ListingReviewNotification, ListingNotification, Listing Change
+    #   ListingSubmissionNotification, PendingDeletionToStewardNotification, PendingDeletionToOwnerNotification,
+    #  ListingPrivateStatusNotification, ListingReviewNotification, ListingNotification, Listing Change,
+    #  PendingDeletionApprovedNotification
     listing_notification_flag = models.BooleanField(default=True)
     # subscription_notification_flag  will disable/enable:
     #    TagSubscriptionNotification, CategorySubscriptionNotification
@@ -1627,8 +1628,9 @@ class Notification(models.Model):
     LISTING_NEW = 'listing_new'
     LISTING_REVIEW = 'listing_review'  # When a review is left on a listing
     LISTING_PRIVATE_STATUS = 'listing_private_status'  # When a listing is changed to private
-    PENDING_DELETION_REQUEST = 'pending_deletion_request'  # When a steward approves an app deletion request
-    PENDING_DELETION_CANCELLATION = 'pending_deletion_cancellation'  # When a steward rejects an app deletion request
+    PENDING_DELETION_TO_OWNER = 'pending_deletion_to_owner'  # When a steward rejects an app deletion request
+    PENDING_DELETION_TO_STEWARD = 'pending_deletion_to_steward'  # When an owner submits or cancels an app deletion request
+    PENDING_DELETION_APPROVED = 'pending_deletion_approved'  # When a steward approves an app deletion request
     REVIEW_REQUEST = 'review_request'  # When an APP_STEWARD notifies ORG_STEWARDS to review their apps and makes sure they are up to date
     SUBSCRIPTION_CATEGORY = 'subscription_category'  # When there is a new app in a subscribed category
     SUBSCRIPTION_TAG = 'subscription_tag'  # When there is a new app in a subscribed tag
@@ -1637,8 +1639,9 @@ class Notification(models.Model):
         (LISTING_NEW, 'listing_new'),
         (LISTING_REVIEW, 'listing_review'),
         (LISTING_PRIVATE_STATUS, 'listing_private_status'),
-        (PENDING_DELETION_REQUEST, 'pending_deletion_request'),
-        (PENDING_DELETION_CANCELLATION, 'pending_deletion_cancellation'),
+        (PENDING_DELETION_TO_OWNER, 'pending_deletion__to_owner'),
+        (PENDING_DELETION_TO_STEWARD, 'pending_deletion_to_steward'),
+        (PENDING_DELETION_APPROVED, 'pending_deletion_approved'),
         (REVIEW_REQUEST, 'review_request'),
         (SUBSCRIPTION_CATEGORY, 'subscription_category'),
         (SUBSCRIPTION_TAG, 'subscription_tag')


### PR DESCRIPTION
AMLOS-490

**Description**     
"Pend for deletion" request should launch notification to org steward.

**Acceptance Criteria**   
Steps to verify:
Pre-req- set jones as owner of Chart Course App
Log on as jones 
Edit Chart Course and set to pend for deletion 
Log on as org steward ( julia) 
RESULTS - Should have a notification that mentions the pending for deletion request.
 
**How to test code**    
Pull this branch. Pull  pending_deletion_notification_updates from react commons.
As jones, pend a listing for delete. Bigbrother and julia should receive notification.
As jones, cancel the request. Bigbrother and julia should receive notification.
As jones, pend a listing for delete.
As bigbrother and julia, return the request. Jones should receive a notification
As jones, pend a listing for delete.
As bigbrother and julia, approve the request. Jones, bigbrother, and julia should receive a notification that the listing was deleted.

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

