### PR TITLE
feat(category_description): increase category description length

### DIFF
--- a/ozpcenter/models.py
+++ b/ozpcenter/models.py
@@ -463,7 +463,7 @@ class Category(models.Model):
     TODO: Auditing for create, update, delete
     """
     title = models.CharField(max_length=50, unique=True)
-    description = models.CharField(max_length=255, null=True, blank=True)
+    description = models.CharField(max_length=500, null=True, blank=True)
 
     def __repr__(self):
         return self.title


### PR DESCRIPTION
AMLOS-571

**Description**     
User submitted a ticket to increase the category description from 255 to a higher value.

**Acceptance Criteria**   
User can create or update a description of a category using more than 255 characters
 
**How to test code**    
Pull both `category_length_increase` ozp-center & ozp-backend branches

Login as a user that can create/edit categories (bigbrother)
Go to Center Settings -> Categories
Choose a category and click Edit
Verify the dialog box allows for upto 500 characters for the description.
- Says 'Max. 500 characters'
- Typing more than 500 with cause a red error
- Typing < 500 will allow for the user to submit it.


**Please Review**     
@aml-development/ozp-backend-team    


**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

