### PR TITLE
fix(frequently visited listings): remove disabled listings from query

### DIFF
--- a/ozpcenter/api/profile/model_access.py
+++ b/ozpcenter/api/profile/model_access.py
@@ -123,7 +123,7 @@ def get_frequently_visited_listings(current_request_username, profile_id):
     else:
         profile_instance = models.Profile.objects.get(id=profile_id)
 
-    visit_counts = models.ListingVisitCount.objects.select_related('listing').filter(profile=profile_instance, count__gt=0, listing__is_deleted=False).order_by('-count', 'listing__title')
+    visit_counts = models.ListingVisitCount.objects.select_related('listing').filter(profile=profile_instance, count__gt=0, listing__is_deleted=False, listing__is_enabled=True).order_by('-count', 'listing__title')
     listings = [vc.listing for vc in visit_counts]
 
     return listings


### PR DESCRIPTION
AMLNG-652

**Description**     
AML 3.0 Storefront has a section for frequently visited applications.  An endpoint needs to be created to allow the storage of viewed/launch applications in the user's profile info. 

**Acceptance Criteria**   
End point available to track number of visits to an application by a user
End point available to remove a listing from frequently viewed listings
 
**How to test code**    
Check out this branch.  Make the API call to get frequently visited listings, ie
```
curl -X GET --header 'Accept: application/json' --header 'X-CSRFToken: 2QR376YTKa7HvyOR7m9yCb6l1iPizsQcS0tkZilPnvAOGfrDbcEcJkOkAn3z9QAV' 'http://localhost:8001/api/profile/self/listingvisits/frequent/'
```
Ensure that disabled listings do not show up in the results.  If you disable a listing, ensure the results are updated to reflect that change.

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

