### PR TITLE
feat(work role): add work roles to metadata API call

### DIFF
--- a/ozpcenter/api/storefront/model_access.py
+++ b/ozpcenter/api/storefront/model_access.py
@@ -441,6 +441,7 @@ def get_metadata(username):
         * listing types
         * intents
         * contact types
+        * work roles
 
     Key: metadata
     """
@@ -457,6 +458,9 @@ def get_metadata(username):
 
         data['intents'] = values_query_set_to_dict(models.Intent.objects.all().values(
             'action', 'media_type', 'label', 'icon', 'id'))
+
+        data['work_roles'] = values_query_set_to_dict(models.WorkRole.objects.all().values(
+            'id', 'name'))
 
         agency_listing_count_queryset = models.Listing.objects.for_user(username).filter(approval_status=models.Listing.APPROVED, is_enabled=True)
         agency_listing_count_queryset = agency_listing_count_queryset.values('agency__id',

--- a/ozpcenter/api/storefront/views.py
+++ b/ozpcenter/api/storefront/views.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('ozp-center.' + str(__name__))
 def MetadataView(request):
     """
     Metadata for the store including categories, agencies, contact types,
-    intents, and listing types
+    work roles, intents, and listing types
     """
     request_username = request.user.username
     data = model_access.get_metadata(request_username)

--- a/tests/ozpcenter_api/test_api_storefront.py
+++ b/tests/ozpcenter_api/test_api_storefront.py
@@ -36,6 +36,7 @@ class StorefrontApiTest(APITestCase):
         self.assertIn('contact_types', response.data)
         self.assertIn('listing_types', response.data)
         self.assertIn('intents', response.data)
+        self.assertIn('work_roles', response.data)
 
         for i in response.data['agencies']:
             self.assertTrue('listing_count' in i)

--- a/tests/ozpcenter_model_access/test_storefront.py
+++ b/tests/ozpcenter_model_access/test_storefront.py
@@ -84,6 +84,11 @@ class StorefrontTest(TestCase):
         expected_keys = ['title', 'description'].sort()
         self.assertEqual(keys, expected_keys)
 
+        work_roles = metadata['work_roles']
+        keys = list(work_roles[0].keys()).sort()
+        expected_keys = ['id', 'name'].sort()
+        self.assertEqual(keys, expected_keys)
+
     # TODO: Fails on postgres
     # def test_get_sql_statement(self):
     #     sql = model_access.get_sql_statement()


### PR DESCRIPTION
AMLOS-715

**Description**     
Work roles need to be added to the system so that they can be edited on the user profile.  

**Acceptance Criteria**   
An apps mall steward can add, update, delete work roles via API
A user can get a list of work roles in the system
The API call for editing a profile updates the user's work roles
 
**How to test code**    
This is a continuation of https://github.com/aml-development/ozp-backend/pull/432

This adds a list of work roles to the `GET /api/metadata` call

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

