### PR TITLE
fix(ws_service): sending notification to correct user id

### DIFF
--- a/ozpcenter/wsservice/wsclient.py
+++ b/ozpcenter/wsservice/wsclient.py
@@ -97,7 +97,7 @@ class WebServiceClient(object):
 
             data_to_send.append(
                 {
-                    "target": "{}".format(notification_mail_box.target_profile.id),
+                    "target": "{}".format(notification_mail_box.target_profile.user.id),
                     "channel": "notification",
                     "payload": current_data
                 }


### PR DESCRIPTION
AMLOS-741

**Description**     
Send notification to correct user id

**Acceptance Criteria**   
Notification is sent to correct user id
 
**How to test code**    
Error use to only happen for PKI notifications.  the PKI use created two users but was incomplete

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

