### PR TITLE
feat(bookmarks): create a folder with a listing

### DIFF
--- a/ozpcenter/api/bookmark/model_access.py
+++ b/ozpcenter/api/bookmark/model_access.py
@@ -356,7 +356,7 @@ def create_get_user_root_bookmark_folder(request_profile):
         return bookmark_entry
 
 
-def create_folder_bookmark_for_profile(request_profile, folder_name, bookmark_entry_folder=None, bookmark_children=None):
+def create_folder_bookmark_for_profile(request_profile, folder_name, bookmark_entry_folder=None, bookmark_children=None, listing_object=None):
     """
     Create Folder Bookmark for profile
 
@@ -386,14 +386,15 @@ def create_folder_bookmark_for_profile(request_profile, folder_name, bookmark_en
         target_user_type=models.BookmarkPermission.OWNER
     )
 
-    print(bookmark_children)
-
     for bookmark_child in bookmark_children:
         update_bookmark_entry_for_profile(
             request_profile,
             get_bookmark_entry_by_id(request_profile, bookmark_child),
             bookmark_folder_entry,
             None)
+
+    if listing_object:
+        create_listing_bookmark_for_profile(request_profile, listing_object, bookmark_folder_entry)
 
     return bookmark_folder_entry
 

--- a/ozpcenter/api/bookmark/serializers.py
+++ b/ozpcenter/api/bookmark/serializers.py
@@ -35,9 +35,9 @@ class LibraryListingSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Listing
         fields = ('id', 'title', 'unique_name', 'launch_url', 'small_icon',
-            'large_icon', 'banner_icon', 'owners', 'security_marking')
+            'large_icon', 'banner_icon', 'owners', 'security_marking', 'is_enabled')
         read_only_fields = ('title', 'unique_name', 'launch_url', 'small_icon',
-            'large_icon', 'banner_icon', 'owners', 'security_marking')
+            'large_icon', 'banner_icon', 'owners', 'security_marking', 'is_enabled')
         # Any AutoFields on your model (which is what the automatically
         # generated id key is) are set to read-only by default when Django
         # REST Framework is creating fields in the background. read-only fields

--- a/ozpcenter/models.py
+++ b/ozpcenter/models.py
@@ -1184,6 +1184,7 @@ class StorefrontCustomizationManager(models.Manager):
     """
     Use a custom manager to control access to storefront customizations
     """
+
     def apply_select_related(self, queryset):
         queryset = queryset.select_related('profile')
         queryset = queryset.select_related('profile__user')

--- a/ozpcenter/scripts/test_data/agency.yaml
+++ b/ozpcenter/scripts/test_data/agency.yaml
@@ -1,0 +1,27 @@
+- icon.filename: ministry_of_truth.jpg
+  short_name: Minitrue
+  title: Ministry of Truth
+- icon.filename: ministry_of_peace.png
+  short_name: Minipax
+  title: Ministry of Peace
+- icon.filename: ministry_of_love.jpeg
+  short_name: Miniluv
+  title: Ministry of Love
+- icon.filename: ministry_of_plenty.png
+  short_name: Miniplen
+  title: Ministry of Plenty
+- icon.filename: ministry_of_plenty.png
+  short_name: Test
+  title: Test
+- icon.filename: ministry_of_plenty.png
+  short_name: Test 1
+  title: Test 1
+- icon.filename: ministry_of_plenty.png
+  short_name: Test2
+  title: Test 2
+- icon.filename: ministry_of_plenty.png
+  short_name: Test 3
+  title: Test 3
+- icon.filename: ministry_of_plenty.png
+  short_name: Test 4
+  title: Test 4

--- a/ozpcenter/scripts/test_data/subscriptions.yaml
+++ b/ozpcenter/scripts/test_data/subscriptions.yaml
@@ -1,0 +1,6 @@
+- type: category
+  username: bigbrother
+  value: Books and Reference
+- type: category
+  username: bigbrother
+  value: Business

--- a/ozpcenter/scripts/test_data/system_notification.yaml
+++ b/ozpcenter/scripts/test_data/system_notification.yaml
@@ -1,0 +1,12 @@
+- message: System will be going down for approximately 30 minutes on X/Y at 1100Z
+  time: next_week
+  username: wsmith
+- message: System will be functioning in a degredaded state between 1800Z-0400Z on A/B
+  time: next_week
+  username: julia
+- message: System will be going down for approximately 30 minutes on C/D at 1700Z
+  time: last_week
+  username: wsmith
+- message: System will be functioning in a degredaded state between 2100Z-0430Z on F/G
+  time: last_week
+  username: julia

--- a/tests/ozp/bookmark_helper.py
+++ b/tests/ozp/bookmark_helper.py
@@ -111,11 +111,11 @@ def _bookmark_node_parse_shorthand_commands(data):
             0 - L -  Diamond
             0 - L -  Grandfather clock
 
-            CREATE_FOLDER_PUSH_PEEK-heros
-            CREATE_LISTING_PEEK-Iron Man
-            CREATE_LISTING_PEEK-Jean Grey
-            CREATE_LISTING_PEEK-Mallrats
-            CREATE_FOLDER_POP_PUSH_PEEK-old
+    Returns:
+        [{'action': 'CREATE_FOLDER',
+          'level_diff': 0,
+          'record_title': 'bigbrother',
+          'stack_action': 'PUSH_PEEK'},...]
     """
     commands = []
 
@@ -203,7 +203,7 @@ def _bookmark_node_parse_shorthand_commands(data):
             previous_is_folder = record_is_folder
             continue
 
-        commands.append('{}-{}-{}-{}'.format(action, record_title, stack_action, level_diff))
+        commands.append({'action': action, 'record_title': record_title, 'stack_action': stack_action, 'level_diff': level_diff})  # '{}-{}-{}-{}'.format(action, record_title, stack_action, level_diff))
         # print("{}({}) {}".format(action, level_diff, record_title))
         # set previous level
         previous_level = record_level
@@ -256,12 +256,11 @@ def _bookmark_node_parse_shorthand(data):
     folder_stack = [root_folder]
     commands = _bookmark_node_parse_shorthand_commands(data)
     # import pprint; pprint.pprint(commands)
-    for command in commands:
-        command_split = command.split('-')
-        action_raw = command_split[0]
-        record_title = command_split[1]
-        stack_action = command_split[2]
-        level_diff = int(command_split[3])
+    for command_dict in commands:
+        action_raw = command_dict['action']
+        record_title = command_dict['record_title']
+        stack_action = command_dict['stack_action']
+        level_diff = int(command_dict['level_diff'])
 
         action = '{}_{}'.format(action_raw, stack_action)
 

--- a/tests/ozp/bookmark_helper.py
+++ b/tests/ozp/bookmark_helper.py
@@ -63,6 +63,155 @@ def _parse_legacy_bookmark(data):
     return root_folder
 
 
+def _bookmark_node_parse_shorthand_commands(data):
+    """
+    Convert Shorthand Data into Commands
+
+    Actions: (BOOKMARK CLASS _ FOLDER STACK ACTION)
+        CF_PU: CREATE_FOLDER_PUSH_PEEK
+            0-F   0-None
+            1-F   0-F
+        CF_PO: CREATE_FOLDER_POP_PUSH_PEEK
+            0-F   1-L
+            0-F   0-F
+        CL_PE: CREATE_LISTING_PEEK
+            1-F   0-L    0-NONE
+            2-L   0-L    0-L
+        CL_PO: CREATE_LISTING_POP_PEEK
+            1-L   1-F
+            0-L   0-L
+
+        Args:
+            data:
+                ['(F) heros',
+                 ' (L) Iron Man',
+                 ' (L) Jean Grey',
+                 ' (L) Mallrats',
+                 '(F) old',
+                 ' (L) Air Mail',
+                 ' (L) Bread Basket',
+                 '(F) planets',
+                 ' (L) Azeroth',
+                 ' (L) Saturn',
+                 '(L) Baltimore Ravens',
+                 '(L) Diamond',
+                 '(L) Grandfather clock']
+
+            0 - F -  heros
+            1 - L -  Iron Man
+            1 - L -  Jean Grey
+            1 - L -  Mallrats
+            0 - F -  old
+            1 - L -  Air Mail
+            1 - L -  Bread Basket
+            0 - F -  planets
+            1 - L -  Azeroth
+            1 - L -  Saturn
+            0 - L -  Baltimore Ravens
+            0 - L -  Diamond
+            0 - L -  Grandfather clock
+
+            CREATE_FOLDER_PUSH_PEEK-heros
+            CREATE_LISTING_PEEK-Iron Man
+            CREATE_LISTING_PEEK-Jean Grey
+            CREATE_LISTING_PEEK-Mallrats
+            CREATE_FOLDER_POP_PUSH_PEEK-old
+    """
+    commands = []
+
+    previous_level = 0
+    previous_is_folder = False
+
+    for current_record in data:
+        current_record_re = re.search('(^[ ]*)\(([\w]+)\)(.*$)', current_record)
+
+        record_level = len(current_record_re.group(1))
+        record_type = current_record_re.group(2)
+        record_title = str(current_record_re.group(3)).strip()
+        record_is_folder = False
+
+        folder_type = 'FOLDER'
+
+        if record_type == 'F' or record_type == 'SF':
+            record_is_folder = True
+
+        if record_type == 'SF':
+            folder_type = 'SHARED_FOLDER'
+
+        # print('-'*10)
+        # print('previous_level: {} - previous_is_folder: {} - record_level: {} - record_type: {} - record_title: {}'.format(previous_level, previous_is_folder, record_level, record_type, record_title))
+
+        bookmark_class = False
+
+        if record_type in ['F', 'SF', 'L', 'SL']:
+            bookmark_class = True
+
+        if not bookmark_class:
+            previous_level = record_level
+            previous_is_folder = record_is_folder
+            continue
+
+        level_action = 'LEVEL_ERROR'
+        level_diff = 0
+
+        if record_level >= previous_level + 1:
+            level_action = 'LEVEL_UP'
+            level_diff = record_level - previous_level
+        elif record_level <= previous_level - 1:
+            level_action = 'LEVEL_DOWN'
+            level_diff = previous_level - record_level
+        elif record_level == previous_level:
+            level_action = 'LEVEL_SAME'
+
+        action = None
+        stack_action = None
+
+        if record_is_folder:
+            if level_action == 'LEVEL_UP' and previous_is_folder is True:
+                action = 'CREATE_{}'.format(folder_type)
+                stack_action = 'PUSH_PEEK'
+            elif level_action == 'LEVEL_SAME' and previous_is_folder is True:
+                action = 'CREATE_{}'.format(folder_type)
+                stack_action = 'POP_PUSH_PEEK'
+                level_diff = 1 if level_diff == 0 else level_diff
+            elif level_action == 'LEVEL_SAME' and previous_is_folder is False:
+                action = 'CREATE_{}'.format(folder_type)
+                stack_action = 'PUSH_PEEK'
+            elif level_action == 'LEVEL_DOWN':
+                action = 'CREATE_{}'.format(folder_type)
+                stack_action = 'POP_PUSH_PEEK'
+                level_diff = 1 if level_diff == 0 else level_diff
+        else:
+            if level_action == 'LEVEL_UP' and previous_is_folder is True:
+                action = 'CREATE_LISTING'
+                stack_action = 'PEEK'
+            elif level_action == 'LEVEL_SAME' and previous_is_folder is True:
+                action = 'CREATE_LISTING'
+                stack_action = 'POP_PEEK'
+                level_diff = 1 if level_diff == 0 else level_diff
+            elif level_action == 'LEVEL_SAME' and previous_is_folder is False:
+                action = 'CREATE_LISTING'
+                stack_action = 'POP_PEEK'
+            elif level_action == 'LEVEL_DOWN':
+                action = 'CREATE_LISTING'
+                stack_action = 'POP_PEEK'
+
+        # print('level_action: {} - action: {}, level_diff:{}'.format(level_action, action, level_diff, record_level))
+
+        if not action or not stack_action:
+            previous_level = record_level
+            previous_is_folder = record_is_folder
+            continue
+
+        commands.append('{}-{}-{}-{}'.format(action, record_title, stack_action, level_diff))
+        # print("{}({}) {}".format(action, level_diff, record_title))
+        # set previous level
+        previous_level = record_level
+        previous_is_folder = record_is_folder
+
+    return commands
+
+
 def _bookmark_node_parse_shorthand(data):
     """
     Convert Shorthand Data into BookmarkFolder
@@ -96,26 +245,6 @@ def _bookmark_node_parse_shorthand(data):
              '(L) Baltimore Ravens',
              '(L) Diamond',
              '(L) Grandfather clock']
-
-            0 - F -  heros
-            1 - L -  Iron Man
-            1 - L -  Jean Grey
-            1 - L -  Mallrats
-            0 - F -  old
-            1 - L -  Air Mail
-            1 - L -  Bread Basket
-            0 - F -  planets
-            1 - L -  Azeroth
-            1 - L -  Saturn
-            0 - L -  Baltimore Ravens
-            0 - L -  Diamond
-            0 - L -  Grandfather clock
-
-            CREATE_FOLDER_PUSH_PEEK (heros)
-            CREATE_LISTING_PEEK (Iron Man)
-            CREATE_LISTING_PEEK (Jean Grey)
-            CREATE_LISTING_PEEK (Mallrats)
-            CREATE_FOLDER_POP_PUSH_PEEK (old)
             ...
 
     Return:
@@ -125,108 +254,59 @@ def _bookmark_node_parse_shorthand(data):
     root_folder.raw_data = data
 
     folder_stack = [root_folder]
+    commands = _bookmark_node_parse_shorthand_commands(data)
+    # import pprint; pprint.pprint(commands)
+    for command in commands:
+        command_split = command.split('-')
+        action_raw = command_split[0]
+        record_title = command_split[1]
+        stack_action = command_split[2]
+        level_diff = int(command_split[3])
 
-    previous_level = 0
-    previous_is_folder = False
-
-    for current_record in data:
-        current_record_re = re.search('(^[ ]*)\(([\w]+)\)(.*$)', current_record)
-
-        record_level = len(current_record_re.group(1))
-        record_type = current_record_re.group(2)
-        record_title = str(current_record_re.group(3)).strip()
-        record_is_folder = False
-
-        if record_type == 'F' or record_type == 'SF':
-            record_is_folder = True
-
-        # print('-'*10)
-        # print('previous_level: {} - previous_is_folder: {} - record_level: {} - record_type: {} - record_title: {}'.format(previous_level, previous_is_folder, record_level, record_type, record_title))
-
-        bookmark_class = None
-
-        if record_type == 'F':
-            bookmark_class = BookmarkFolder
-        elif record_type == 'SF':
-            bookmark_class = BookmarkSharedFolder
-        elif record_type == 'L' or record_type == 'SL':
-            bookmark_class = BookmarkListing
-
-        if not bookmark_class:
-            previous_level = record_level
-            previous_is_folder = record_is_folder
-            continue
-
-        level_action = 'LEVEL_ERROR'
-        level_diff = 0
-
-        if record_level >= previous_level + 1:
-            level_action = 'LEVEL_UP'
-            level_diff = record_level - previous_level
-        elif record_level <= previous_level - 1:
-            level_action = 'LEVEL_DOWN'
-            level_diff = previous_level - record_level
-        elif record_level == previous_level:
-            level_action = 'LEVEL_SAME'
-
-        action = None
-
-        if record_is_folder:
-            if level_action == 'LEVEL_UP' and previous_is_folder is True:
-                action = 'CREATE_FOLDER_PUSH_PEEK'
-            elif level_action == 'LEVEL_SAME' and previous_is_folder is True:
-                action = 'CREATE_FOLDER_POP_PUSH_PEEK'
-            elif level_action == 'LEVEL_SAME' and previous_is_folder is False:
-                action = 'CREATE_FOLDER_PUSH_PEEK'
-            elif level_action == 'LEVEL_DOWN':
-                action = 'CREATE_FOLDER_POP_PUSH_PEEK'
-        else:
-            if level_action == 'LEVEL_UP' and previous_is_folder is True:
-                action = 'CREATE_LISTING_PEEK'
-            elif level_action == 'LEVEL_SAME':
-                action = 'CREATE_LISTING_PEEK'
-            elif level_action == 'LEVEL_DOWN':
-                action = 'CREATE_LISTING_POP_PEEK'
-
-        # print('level_action: {} - action: {}, level_diff:{}'.format(level_action, action, level_diff, record_level))
-
-        if not action:
-            previous_level = record_level
-            previous_is_folder = record_is_folder
-            continue
+        action = '{}_{}'.format(action_raw, stack_action)
 
         if action == 'CREATE_FOLDER_PUSH_PEEK':
             current_root_folder = folder_stack[-1]
-            next_root_folder = bookmark_class(record_title)
+            next_root_folder = BookmarkFolder(record_title)
             current_root_folder.add_bookmark_object(next_root_folder)
             folder_stack.append(next_root_folder)
 
         elif action == 'CREATE_FOLDER_POP_PUSH_PEEK':
-            level_diff = 1 if level_diff == 0 else level_diff
             for i in range(0, level_diff):
                 if len(folder_stack) > 1:
                     folder_stack.pop()
 
             current_root_folder = folder_stack[-1]
-            next_root_folder = bookmark_class(record_title)
+            next_root_folder = BookmarkFolder(record_title)
+            current_root_folder.add_bookmark_object(next_root_folder)
+            folder_stack.append(next_root_folder)
+
+        elif action == 'CREATE_SHARED_FOLDER_PUSH_PEEK':
+            current_root_folder = folder_stack[-1]
+            next_root_folder = BookmarkSharedFolder(record_title)
+            current_root_folder.add_bookmark_object(next_root_folder)
+            folder_stack.append(next_root_folder)
+
+        elif action == 'CREATE_SHARED_FOLDER_POP_PUSH_PEEK':
+            for i in range(0, level_diff):
+                if len(folder_stack) > 1:
+                    folder_stack.pop()
+
+            current_root_folder = folder_stack[-1]
+            next_root_folder = BookmarkSharedFolder(record_title)
             current_root_folder.add_bookmark_object(next_root_folder)
             folder_stack.append(next_root_folder)
 
         elif action == 'CREATE_LISTING_PEEK':
             current_root_folder = folder_stack[-1]
-            current_root_folder.add_bookmark_object(bookmark_class(record_title))
+            current_root_folder.add_bookmark_object(BookmarkListing(record_title))
 
         elif action == 'CREATE_LISTING_POP_PEEK':
             for i in range(0, level_diff):
                 if len(folder_stack) > 1:
                     folder_stack.pop()
             current_root_folder = folder_stack[-1]
-            current_root_folder.add_bookmark_object(bookmark_class(record_title))
-
-        # print("{}({}) {}".format(action, level_diff, record_title))
-        # set previous level
-        previous_level = record_level
-        previous_is_folder = record_is_folder
+            current_root_folder.add_bookmark_object(BookmarkListing(record_title))
 
     return root_folder
 
@@ -313,6 +393,51 @@ def bookmark_node_string_helper(bookmark_node, level=0, order=False, show_root=T
         return ['{}(L) {}'.format(' ' * level, bookmark_node.title)]
 
 
+def _build_filesystem_structure(bookmark_node, level=None):
+    """
+    Args:
+        bookmark_node:
+        level:
+    Return:
+        List of tuples
+            [('/', F(None, None, None, 8)),
+             ('/Weather/', F(None, Weather, None, 4)),
+             ('/Weather/Tornado', L(30, Tornado, Weather)),...]
+    """
+    if isinstance(bookmark_node, BookmarkNode):
+        bookmark_title = bookmark_node.title
+        bookmark_node_is_root = bookmark_title is None
+        bookmark_is_hidden = bookmark_node.hidden()
+        level = list(level) if level else []
+    else:
+        return []
+
+    if isinstance(bookmark_node, BookmarkFolder):
+        bookmarks = []
+
+        if not bookmark_node_is_root:
+            level.append(bookmark_title)
+
+        if bookmark_node_is_root:
+            title = '/'
+        else:
+            title = '/{}/'.format('/'.join(level))
+        bookmarks.append((title, bookmark_node))
+
+        # This is needed for order
+        for bookmark in bookmark_node.bookmark_objects:
+            if bookmark.is_hidden:
+                continue
+            current_result = _build_filesystem_structure(bookmark_node=bookmark, level=level)
+            bookmarks = bookmarks + (current_result)
+
+        return bookmarks
+    elif isinstance(bookmark_node, BookmarkListing):
+        level.append(bookmark_title)
+        title = '/{}'.format('/'.join(level))
+        return [(title, bookmark_node)]
+
+
 class BookmarkNode(object):
 
     def __init__(self, id=None, title=None, type=None, is_shared=None, listing_id=None):
@@ -332,7 +457,7 @@ class BookmarkNode(object):
 
     def clone(self):
         # TODO: True Clone of objects.  should include id, listing_id
-        shorten_data = bookmark_node_string_helper(self)
+        shorten_data = self.shorten_data()
         return _bookmark_node_parse_shorthand(shorten_data)
 
     def __str__(self):
@@ -369,17 +494,30 @@ class BookmarkFolder(BookmarkNode):
         return bookmark_listing
 
     def add_bookmark_object(self, bookmark_object, prepend=False):
-        if prepend:
-            self.bookmark_objects.insert(0, bookmark_object)
+        bookmarks = []
+        if bookmark_object.title is None:
+            bookmarks = bookmark_object.bookmark_objects
         else:
-            self.bookmark_objects.append(bookmark_object)
-        bookmark_object.parent = self
+            bookmarks = [bookmark_object]
+
+        for current_bookmark_object in bookmarks:
+            if prepend:
+                self.bookmark_objects.insert(0, current_bookmark_object)
+            else:
+                self.bookmark_objects.append(current_bookmark_object)
+            current_bookmark_object.parent = self
         return True
 
-    def first_shared_folder(self):
-        for bookmark in self.bookmark_objects:
+    def first_shared_folder(self, current_level=None):
+        current_level = current_level if current_level else self
+
+        for bookmark in current_level.bookmark_objects:
             if isinstance(bookmark, BookmarkSharedFolder):
                 return bookmark
+
+            if isinstance(bookmark, BookmarkFolder):
+                return self.first_shared_folder(bookmark)
+
         return None
 
     def first_listing_bookmark(self, current_level=None):
@@ -394,60 +532,11 @@ class BookmarkFolder(BookmarkNode):
 
         return None
 
-    def _build_filesystem_structure(self, bookmark_node=None, level=None):
-        """
-        Args:
-            bookmark_node:
-            level:
-        Return:
-            List of tuples
-                [('/', F(None, None, None, 8)),
-                 ('/Weather/', F(None, Weather, None, 4)),
-                 ('/Weather/Tornado', L(30, Tornado, Weather)),...]
-        """
-        bookmark_node = bookmark_node if bookmark_node else self
-        bookmark_title = bookmark_node.title
-        bookmark_node_is_root = bookmark_title is None
-        bookmark_is_hidden = bookmark_node.hidden
-
-        if isinstance(bookmark_node, BookmarkFolder):
-            bookmarks = []
-
-            if not bookmark_node_is_root:
-                title = None
-                if level:
-                    title = '/{}/{}/'.format(level, bookmark_node.title)
-                else:
-                    title = '/{}/'.format(bookmark_node.title)
-
-                bookmarks.append((title, bookmark_node))
-            else:
-                bookmarks.append(('/', bookmark_node))
-
-            for bookmark in bookmark_node.bookmark_objects:
-                if bookmark.is_hidden:
-                    continue
-
-                current_result = self._build_filesystem_structure(bookmark_node=bookmark, level=bookmark_title)
-
-                if isinstance(current_result, tuple):
-                    bookmarks.append(current_result)
-                elif isinstance(current_result, list):
-                    bookmarks = bookmarks + (current_result)
-            return bookmarks
-        elif isinstance(bookmark_node, BookmarkListing):
-            title = None
-            if level:
-                title = '/{}/{}'.format(level, bookmark_node.title)
-            else:
-                title = '/{}'.format(bookmark_node.title)
-            return (title, bookmark_node)
-
     def search(self, name, directory_tuples=None):
         """
         Search function
         """
-        directory_tuples = directory_tuples if directory_tuples else self._build_filesystem_structure()
+        directory_tuples = directory_tuples if directory_tuples else _build_filesystem_structure(self)
         directory = dict(directory_tuples)
         return directory.get(name)
 
@@ -455,7 +544,7 @@ class BookmarkFolder(BookmarkNode):
         """
         Search function
         """
-        directory_tuples = directory_tuples if directory_tuples else self._build_filesystem_structure()
+        directory_tuples = directory_tuples if directory_tuples else _build_filesystem_structure(self)
         directory = dict(directory_tuples)
         bookmark_object = directory.get(name)
         if bookmark_object is not None:
@@ -463,7 +552,7 @@ class BookmarkFolder(BookmarkNode):
         return False
 
     def move(self, src_name, dest_name):
-        directory_tuples = self._build_filesystem_structure()
+        directory_tuples = _build_filesystem_structure(self)
 
         src_bookmark = self.search(src_name, directory_tuples)
         dest_bookmark = self.search(dest_name, directory_tuples)
@@ -483,7 +572,7 @@ class BookmarkFolder(BookmarkNode):
         return True
 
     def copy(self, src_name, dest_name):
-        directory_tuples = self._build_filesystem_structure()
+        directory_tuples = _build_filesystem_structure(self)
 
         src_bookmark = self.search(src_name, directory_tuples)
         dest_bookmark = self.search(dest_name, directory_tuples)

--- a/tests/ozp/bookmark_helper.py
+++ b/tests/ozp/bookmark_helper.py
@@ -336,8 +336,9 @@ def _bookmark_node_parse(bookmark_folder, data):
         for listing in listings:
             bookmark_id = listing.get('id')
             listing_title = listing.get('listing', {}).get('title')
+            listing_id = listing.get('listing', {}).get('id')
             if listing_title:
-                bookmark_listing = BookmarkListing(listing_title, id=bookmark_id)
+                bookmark_listing = BookmarkListing(listing_title, id=bookmark_id, listing_id=listing_id)
                 bookmark_folder.add_bookmark_object(bookmark_listing)
                 bookmark_listing.set_parent(bookmark_folder)
 

--- a/tests/ozp/bookmark_helper.py
+++ b/tests/ozp/bookmark_helper.py
@@ -478,6 +478,7 @@ class BookmarkNode(object):
 
 
 class BookmarkFolder(BookmarkNode):
+    prefix = 'F'
 
     def __init__(self, title, id=None, is_shared=False):
         super().__init__(id, title, 'FOLDER', is_shared)
@@ -621,17 +622,13 @@ class BookmarkFolder(BookmarkNode):
         bookmark_objects = self.bookmark_objects
         id = self.id
         title = self.title
-        prefix = ''
 
-        if self.is_shared:
-            prefix = 'SF'
-        else:
-            prefix = 'F'
-
-        return '{}({}, {}, {}, {})'.format(prefix, id, title, self.parent.title if self.parent else 'None', len(bookmark_objects))
+        return '{}({}, {}, {}, {})'.format(self.prefix, id, title, self.parent.title if self.parent else 'None', len(bookmark_objects))
 
 
 class BookmarkSharedFolder(BookmarkFolder):
+    prefix = 'SF'
+
     def __init__(self, title, id=None):
         super().__init__(title, id=id, is_shared=True)
 

--- a/tests/ozp/test_bookmark_helper.py
+++ b/tests/ozp/test_bookmark_helper.py
@@ -1,0 +1,268 @@
+"""
+Utils tests
+"""
+from django.test import TestCase
+from django.conf import settings
+
+from tests.ozp.bookmark_helper import BookmarkFolder, BookmarkListing, shorthand_permissions, _build_filesystem_structure
+
+
+class BookmarkHelperTest(TestCase):
+
+    def setUp(self):
+        """
+        setUp is invoked before each test method
+        """
+        self.maxDiff = None
+
+    def test_bookmark_folder_parse_shorthand_bigbrother(self):
+        """
+        Testing parse_shorthand_list method
+        """
+        bigbrother_expected_bookmarks = [
+            '(F) Animals',
+            ' (L) Killer Whale',
+            ' (L) Lion Finder',
+            ' (L) Monkey Finder',
+            ' (L) Parrotlet',
+            ' (L) White Horse',
+            ' (L) Wolf Finder',
+            '(F) Instruments',
+            ' (L) Acoustic Guitar',
+            ' (L) Electric Guitar',
+            ' (L) Electric Piano',
+            ' (L) Piano',
+            ' (L) Sound Mixer',
+            ' (L) Violin',
+            '(F) Weather',
+            ' (L) Lightning',
+            ' (L) Snow',
+            ' (L) Tornado',
+            '(L) Bread Basket',
+            '(L) Chain boat navigation',
+            '(L) Chart Course',
+            '(L) Gallery of Maps',
+            '(L) Informational Book',
+            '(L) Stop sign',
+            # '(L) Stop 1'
+        ]
+
+        bookmark_folder = BookmarkFolder.parse_shorthand_list(bigbrother_expected_bookmarks)
+        self.assertEqual(bookmark_folder.shorten_data(), bigbrother_expected_bookmarks)
+        self.assertEqual(bookmark_folder.clone().shorten_data(), bigbrother_expected_bookmarks)
+
+    def test_bookmark_folder_parse_shorthand_wsmith(self):
+        """
+        Testing parse_shorthand_list method
+        """
+        wsmith_expected_bookmarks = [
+            '(F) heros',
+            ' (L) Iron Man',
+            ' (L) Jean Grey',
+            ' (L) Mallrats',
+            '(F) old',
+            ' (L) Air Mail',
+            ' (L) Bread Basket',
+            '(F) planets',
+            ' (L) Azeroth',
+            ' (L) Saturn',
+            '(L) Baltimore Ravens',
+            '(L) Diamond',
+            '(L) Grandfather clock'
+        ]
+
+        bookmark_folder = BookmarkFolder.parse_shorthand_list(wsmith_expected_bookmarks)
+        self.assertEqual(bookmark_folder.shorten_data(), wsmith_expected_bookmarks)
+        self.assertEqual(bookmark_folder.clone().shorten_data(), wsmith_expected_bookmarks)
+
+        stucture_list = [record[0] for record in _build_filesystem_structure(bookmark_folder)]
+        expected_stucture_list = [
+            '/',
+            '/heros/',
+            '/heros/Iron Man',
+            '/heros/Jean Grey',
+            '/heros/Mallrats',
+            '/old/',
+            '/old/Air Mail',
+            '/old/Bread Basket',
+            '/planets/',
+            '/planets/Azeroth',
+            '/planets/Saturn',
+            '/Baltimore Ravens',
+            '/Diamond',
+            '/Grandfather clock'
+        ]
+
+        self.assertEqual(stucture_list, expected_stucture_list)
+        bookmark_folder.search('/heros/').add_folder_bookmark('Test2')
+        wsmith_expected_bookmarks.insert(1, ' (F) Test2')
+        self.assertEqual(bookmark_folder.shorten_data(), wsmith_expected_bookmarks)
+
+    def test_bookmark_folder_parse_shorthand_simple_listing(self):
+        """
+        Testing parse_shorthand_list method
+        """
+        one_listing_expected_bookmarks = [
+            '(L) Hello'
+        ]
+
+        bookmark_folder = BookmarkFolder.parse_shorthand_list(one_listing_expected_bookmarks)
+        self.assertEqual(bookmark_folder.shorten_data(), one_listing_expected_bookmarks)
+
+    def test_bookmark_folder_parse_shorthand_complex(self):
+        """
+        Test parse_shorthand_list method for nested parsing
+        """
+        nested_expected_bookmarks = [
+            '(F) Folder 1',
+            ' (SF) Folder 1.1',
+            '  (L) Listing 1.1.2',
+            ' (F) Folder 1.2',
+            ' (F) Folder 1.3',
+            '  (L) Listing 1.3.1',
+            ' (F) Folder 1.4',
+            ' (L) Listing 1.1.1',
+            '(F) Folder 2'
+        ]
+        bookmark_folder = BookmarkFolder.parse_shorthand_list(nested_expected_bookmarks)
+        self.assertEqual(bookmark_folder.shorten_data(), nested_expected_bookmarks)
+        self.assertEqual(bookmark_folder.clone().shorten_data(), nested_expected_bookmarks)
+
+        stucture_list = [record[0] for record in _build_filesystem_structure(bookmark_folder)]
+        expected_stucture_list = [
+            '/',
+            '/Folder 1/',
+            '/Folder 1/Folder 1.1/',
+            '/Folder 1/Folder 1.1/Listing 1.1.2',
+            '/Folder 1/Folder 1.2/',
+            '/Folder 1/Folder 1.3/',
+            '/Folder 1/Folder 1.3/Listing 1.3.1',
+            '/Folder 1/Folder 1.4/',
+            '/Folder 1/Listing 1.1.1',
+            '/Folder 2/'
+        ]
+
+        self.assertEqual(stucture_list, expected_stucture_list)
+
+    def test_build_filesystem_structure(self):
+        library = [
+            '(F) bigbrother',  # 0
+            ' (F) Animals',
+            '  (L) Killer Whale',
+            '  (L) Lion Finder',
+            '  (L) Monkey Finder',
+            '  (L) Parrotlet',
+            '  (L) White Horse',
+            '  (L) Wolf Finder',
+            ' (F) Instruments',
+            '  (L) Acoustic Guitar',
+            '  (L) Electric Guitar',
+            '  (L) Electric Piano',
+            '  (L) Piano',
+            '  (L) Sound Mixer',
+            '  (L) Violin',
+            ' (F) Weather',
+            '  (L) Lightning',
+            '  (L) Snow',
+            '  (L) Tornado',  # 19
+            ' (L) Bread Basket',
+            ' (L) Chain boat navigation',
+            ' (L) Chart Course',
+            ' (L) Gallery of Maps',
+            ' (L) Informational Book',
+            ' (L) Stop sign',
+            '(F) bigbrother2',
+            ' (SF) InstrumentSharing',
+            '  (L) Acoustic Guitar',
+            ' (L) Alingano Maisu',
+            '(F) julia',
+            ' (SF) InstrumentSharing',
+            '  (L) Acoustic Guitar',
+            ' (L) Astrology software',
+            '(F) johnson',
+            ' (SF) InstrumentSharing',
+            '  (L) Acoustic Guitar',
+            ' (L) Applied Ethics Inc.',
+            '(F) wsmith',
+            ' (F) heros',
+            '  (L) Iron Man',
+            '  (L) Jean Grey',
+            '  (L) Mallrats',
+            ' (F) old',
+            '  (L) Air Mail',
+            '  (L) Bread Basket',
+            ' (F) planets',
+            '  (L) Azeroth',
+            '  (L) Saturn',
+            ' (L) Baltimore Ravens',
+            ' (L) Diamond',
+            ' (L) Grandfather clock'
+        ]
+
+        bookmark_folder = BookmarkFolder.parse_shorthand_list(library)
+        self.assertEqual(bookmark_folder.shorten_data(), library)
+        self.assertEqual(bookmark_folder.clone().shorten_data(), library)
+
+        stucture_list = [record[0] for record in _build_filesystem_structure(bookmark_folder)]
+        expected_stucture_list = [
+            '/',
+            '/bigbrother/',
+            '/bigbrother/Animals/',
+            '/bigbrother/Animals/Killer Whale',
+            '/bigbrother/Animals/Lion Finder',
+            '/bigbrother/Animals/Monkey Finder',
+            '/bigbrother/Animals/Parrotlet',
+            '/bigbrother/Animals/White Horse',
+            '/bigbrother/Animals/Wolf Finder',
+            '/bigbrother/Instruments/',
+            '/bigbrother/Instruments/Acoustic Guitar',
+            '/bigbrother/Instruments/Electric Guitar',
+            '/bigbrother/Instruments/Electric Piano',
+            '/bigbrother/Instruments/Piano',
+            '/bigbrother/Instruments/Sound Mixer',
+            '/bigbrother/Instruments/Violin',
+            '/bigbrother/Weather/',
+            '/bigbrother/Weather/Lightning',
+            '/bigbrother/Weather/Snow',
+            '/bigbrother/Weather/Tornado',
+            '/bigbrother/Bread Basket',
+            '/bigbrother/Chain boat navigation',
+            '/bigbrother/Chart Course',
+            '/bigbrother/Gallery of Maps',
+            '/bigbrother/Informational Book',
+            '/bigbrother/Stop sign',
+            '/bigbrother2/',
+            '/bigbrother2/InstrumentSharing/',
+            '/bigbrother2/InstrumentSharing/Acoustic Guitar',
+            '/bigbrother2/Alingano Maisu',
+            '/julia/',
+            '/julia/InstrumentSharing/',
+            '/julia/InstrumentSharing/Acoustic Guitar',
+            '/julia/Astrology software',
+            '/johnson/',
+            '/johnson/InstrumentSharing/',
+            '/johnson/InstrumentSharing/Acoustic Guitar',
+            '/johnson/Applied Ethics Inc.',
+            '/wsmith/',
+            '/wsmith/heros/',
+            '/wsmith/heros/Iron Man',
+            '/wsmith/heros/Jean Grey',
+            '/wsmith/heros/Mallrats',
+            '/wsmith/old/',
+            '/wsmith/old/Air Mail',
+            '/wsmith/old/Bread Basket',
+            '/wsmith/planets/',
+            '/wsmith/planets/Azeroth',
+            '/wsmith/planets/Saturn',
+            '/wsmith/Baltimore Ravens',
+            '/wsmith/Diamond',
+            '/wsmith/Grandfather clock'
+        ]
+
+        self.assertEqual(stucture_list, expected_stucture_list)
+
+        bookmark_folder.search('/bigbrother/').add_folder_bookmark('Test Folder 1')
+        library.insert(19, ' (F) Test Folder 1')
+
+        self.assertEqual(bookmark_folder.shorten_data(), library)
+        self.assertEqual(bookmark_folder.clone().shorten_data(), library)

--- a/tests/ozpcenter_api/test_api_bookmark.py
+++ b/tests/ozpcenter_api/test_api_bookmark.py
@@ -2,12 +2,6 @@
 Test bookmark
 
 TEST_MODE=True pytest tests/ozpcenter_api/test_api_bookmark.py
-
-Nodes()
-    .parse(data)
-    .move('/Animals/Killer Whale')
-    .to('/')
-    .search('/Killer Whale').id()
 """
 from django.test import override_settings
 from tests.ozp.cases import APITestCase
@@ -19,23 +13,24 @@ from tests.ozpcenter.helper import ExceptionUnitTestHelper
 from ozpcenter.scripts import sample_data_generator as data_gen
 
 
-def _get_bookmarks_and_check_for_user(testcase_instance, username, expected_results):
-    """
-    Helper Function to get bookmarks for user and check bookmarks against expected_results
-    """
-    url = '/api/bookmark/'
-    response = APITestHelper.request(testcase_instance, url, 'GET', username=username, status_code=200)
-    bookmark_folder = BookmarkFolder.parse_endpoint(response.data)
-    shorten_data = bookmark_folder.shorten_data()
-    # sorted by type, created_date
-    # import pprint
-    # print('--shorten_data--:{}'.format(username))
-    # pprint.pprint(shorten_data)
-    # print('--expected_results--:{}'.format(username))
-    # pprint.pprint(expected_results)
-    # print('===========')
-    testcase_instance.assertEqual(shorten_data, expected_results, 'username:{}'.format(username))
-    return response.data
+def _compare_bookmarks(test_case_instance, expected_library_object):
+    usernames = [bookmark.title for bookmark in expected_library_object.bookmark_objects]
+
+    root_folder = BookmarkFolder(None)
+
+    for username in usernames:
+        user_folder_bookmark = root_folder.add_folder_bookmark(username)
+
+        url = '/api/bookmark/'
+        response = APITestHelper.request(test_case_instance, url, 'GET', username=username, status_code=200)
+        actual_library = BookmarkFolder.parse_endpoint(response.data)
+        user_folder_bookmark.add_bookmark_object(actual_library)
+
+    actual_bookmarks = root_folder.shorten_data(order=False)
+    expected_bookmarks = expected_library_object.shorten_data(order=False)
+
+    test_case_instance.assertEqual(actual_bookmarks, expected_bookmarks)
+    return root_folder
 
 
 def _get_folder_permission(testcase_instance, username, folder_id, permission_shorthand_expected, status_code=200):
@@ -53,11 +48,39 @@ def _get_folder_permission(testcase_instance, username, folder_id, permission_sh
         testcase_instance.assertEqual(response.data.get('error_code'), 'permission_denied')
 
 
+def _create_bookmark_folder(testcase_instance, username, folder_title, listing_id=None, shared_folder_id=None):
+    """
+    Create Listing bookmark under shared_folder_bookmark
+
+    CREATE [LISTING/FOLDER] BOOKMARK FOR USER {username} WHERE LISTING = {listing_id}
+    """
+    url = '/api/bookmark/'
+    data = {"type": "FOLDER", "title": folder_title}
+
+    if listing_id:
+        data['listing'] = {}
+        data['listing']['id'] = listing_id
+
+    if shared_folder_id:
+        data['bookmark_parent'] = [{"id": shared_folder_id}]
+
+    response = APITestHelper.request(testcase_instance, url, 'POST', data=data, username=username, status_code=201)
+
+    shorten_data = shorthand_dict(response.data, include_keys=['is_shared', 'type', 'title'])
+    expected_results = "(is_shared:False,title:{},type:FOLDER)".format(folder_title)
+    testcase_instance.assertEqual(shorten_data, expected_results)
+    return response
+
+
 def _create_bookmark_listing(testcase_instance, username, listing_id, listing_title, shared_folder_id=None):
-    # Create Listing bookmark under shared_folder_bookmark
+    """
+    Create Listing bookmark under shared_folder_bookmark
+
+    CREATE [LISTING/FOLDER] BOOKMARK FOR USER {username} WHERE LISTING = {listing_id}
+    """
     url = '/api/bookmark/'
     # TODO: How to elimate listing id from call
-    data = {"type": "LISTING", "listing": {"id": 2}}
+    data = {"type": "LISTING", "listing": {"id": listing_id}}
 
     if shared_folder_id:
         data['bookmark_parent'] = [{"id": shared_folder_id}]
@@ -86,63 +109,60 @@ class BookmarkApiTest(APITestCase):
         """
         self.maxDiff = None
 
-        self.bigbrother_expected_bookmarks = [
-            '(F) Animals',
-            ' (L) Killer Whale',
-            ' (L) Lion Finder',
-            ' (L) Monkey Finder',
-            ' (L) Parrotlet',
-            ' (L) White Horse',
-            ' (L) Wolf Finder',
-            '(F) Instruments',
-            ' (L) Acoustic Guitar',
-            ' (L) Electric Guitar',
-            ' (L) Electric Piano',
-            ' (L) Piano',
-            ' (L) Sound Mixer',
-            ' (L) Violin',
-            '(F) Weather',
-            ' (L) Lightning',
-            ' (L) Snow',
-            ' (L) Tornado',
-            '(L) Bread Basket',
-            '(L) Chain boat navigation',
-            '(L) Chart Course',
-            '(L) Gallery of Maps',
-            '(L) Informational Book',
-            '(L) Stop sign',
-            # '(L) Stop 1'
-        ]
-
-        self.wsmith_expected_bookmarks = [
-            '(F) heros',
-            ' (L) Iron Man',
-            ' (L) Jean Grey',
-            ' (L) Mallrats',
-            '(F) old',
-            ' (L) Air Mail',
+        self.library = [
+            '(F) bigbrother',
+            ' (F) Animals',
+            '  (L) Killer Whale',
+            '  (L) Lion Finder',
+            '  (L) Monkey Finder',
+            '  (L) Parrotlet',
+            '  (L) White Horse',
+            '  (L) Wolf Finder',
+            ' (F) Instruments',
+            '  (L) Acoustic Guitar',
+            '  (L) Electric Guitar',
+            '  (L) Electric Piano',
+            '  (L) Piano',
+            '  (L) Sound Mixer',
+            '  (L) Violin',
+            ' (F) Weather',
+            '  (L) Lightning',
+            '  (L) Snow',
+            '  (L) Tornado',
             ' (L) Bread Basket',
-            '(F) planets',
-            ' (L) Azeroth',
-            ' (L) Saturn',
-            '(L) Baltimore Ravens',
-            '(L) Diamond',
-            '(L) Grandfather clock'
+            ' (L) Chain boat navigation',
+            ' (L) Chart Course',
+            ' (L) Gallery of Maps',
+            ' (L) Informational Book',
+            ' (L) Stop sign',
+            '(F) bigbrother2',
+            ' (SF) InstrumentSharing',
+            '  (L) Acoustic Guitar',
+            ' (L) Alingano Maisu',
+            '(F) julia',
+            ' (SF) InstrumentSharing',
+            '  (L) Acoustic Guitar',
+            ' (L) Astrology software',
+            '(F) johnson',
+            ' (SF) InstrumentSharing',
+            '  (L) Acoustic Guitar',
+            ' (L) Applied Ethics Inc.',
+            '(F) wsmith',
+            ' (F) heros',
+            '  (L) Iron Man',
+            '  (L) Jean Grey',
+            '  (L) Mallrats',
+            ' (F) old',
+            '  (L) Air Mail',
+            '  (L) Bread Basket',
+            ' (F) planets',
+            '  (L) Azeroth',
+            '  (L) Saturn',
+            ' (L) Baltimore Ravens',
+            ' (L) Diamond',
+            ' (L) Grandfather clock'
         ]
-
-        self.one_listing_expected_bookmarks = [
-            '(L) Hello'
-        ]
-
-        self.nested_expected_bookmarks = [
-            '(F) Folder 1',
-            ' (SF) Folder 1.1',
-            ' (F) Folder 1.2',
-            ' (F) Folder 1.3',
-            '  (L) Listing 1.3.1',
-            ' (L) Listing 1.1.1',
-            '(F) Folder 2'
-        ]
+        self.library_object = BookmarkFolder.parse_shorthand_list(self.library)
 
     @classmethod
     def setUpTestData(cls):
@@ -151,22 +171,11 @@ class BookmarkApiTest(APITestCase):
         """
         data_gen.run()
 
-    def test_bookmark_folder_parse_shorthand(self):
+    def test_bookmark_list_all_users(self):
         """
-        Testing parse_shorthand_list method
+        Check bookmarks for all users under library_object
         """
-        bookmark_folder = BookmarkFolder.parse_shorthand_list(self.bigbrother_expected_bookmarks)
-        self.assertEqual(bookmark_folder.shorten_data(), self.bigbrother_expected_bookmarks)
-
-        bookmark_folder = BookmarkFolder.parse_shorthand_list(self.wsmith_expected_bookmarks)
-        self.assertEqual(bookmark_folder.shorten_data(), self.wsmith_expected_bookmarks)
-
-        bookmark_folder = BookmarkFolder.parse_shorthand_list(self.one_listing_expected_bookmarks)
-        self.assertEqual(bookmark_folder.shorten_data(), self.one_listing_expected_bookmarks)
-
-    def test_bookmark_folder_parse_shorthand_complex(self):
-        bookmark_folder = BookmarkFolder.parse_shorthand_list(self.nested_expected_bookmarks)
-        self.assertEqual(bookmark_folder.shorten_data(), self.nested_expected_bookmarks)
+        _compare_bookmarks(self, self.library_object)
 
     def test_get_bookmark_list_admin_disable_listing(self):
         """
@@ -174,71 +183,108 @@ class BookmarkApiTest(APITestCase):
         """
         pass
 
-    def test_bookmark_list_admin(self):
+    def test_listing_bookmark_owner_create_delete(self):
         """
-        Check bookmarks for admin (bigbrother)
-        """
-        _get_bookmarks_and_check_for_user(self, 'bigbrother', self.bigbrother_expected_bookmarks)
+        Test for creating listing bookmark under a non-shared folder and deleting same bookmark
 
-    def test_bookmark_list_steward(self):
+        Steps:
+            1. Validate existing bookmarks for bigbrother
+            2. Add a listing bookmark under root folder for bigbrother
+            3. Validate existing
         """
-        Test for checking bookmarks for wsmith user
-        """
-        _get_bookmarks_and_check_for_user(self, 'wsmith', self.wsmith_expected_bookmarks)
+        new_library_object = _compare_bookmarks(self, self.library_object)
 
-    def test_get_bookmark_list_shared_folder(self):
+        response = _create_bookmark_listing(self, 'bigbrother', 2, 'Air Mail')
+        # Verify bookmarks
+        new_library_object.search('/bigbrother/').add_listing_bookmark('Air Mail')
+
+        new_library_object = _compare_bookmarks(self, new_library_object)
+
+        username = 'bigbrother'
+        url = '/api/bookmark/{}/'.format(response.data['id'])
+        response = APITestHelper.request(self, url, 'DELETE', username=username, status_code=204)
+
+        new_library_object.search_delete('/bigbrother/Air Mail')
+
+        new_library_object = _compare_bookmarks(self, new_library_object)
+
+    def test_folder_bookmark_owner_create_delete(self):
+        """
+        Test for creating listing bookmark under a non-shared folder and deleting same bookmark
+
+        Steps:
+            1. Validate existing bookmarks for bigbrother
+            2. Add a listing bookmark under root folder for bigbrother
+            3. Validate existing
+        """
+        new_library_object = _compare_bookmarks(self, self.library_object)
+
+        response = _create_bookmark_folder(self, 'bigbrother', 'Test Folder 1')
+        # Verify bookmarks
+        new_library_object.search('/bigbrother/').add_folder_bookmark('Test Folder 1')
+
+        new_library_object = _compare_bookmarks(self, new_library_object)
+
+        username = 'bigbrother'
+        url = '/api/bookmark/{}/'.format(response.data['id'])
+        response = APITestHelper.request(self, url, 'DELETE', username=username, status_code=204)
+
+        new_library_object.search_delete('/bigbrother/Test Folder 1/')
+
+        new_library_object = _compare_bookmarks(self, new_library_object)
+
+    def test_folder_bookmark_listing_owner_create_delete(self):
+        """
+        Test for creating listing bookmark under a non-shared folder and deleting same bookmark
+
+        Steps:
+            1. Validate existing bookmarks for bigbrother
+            2. Add a listing bookmark under root folder for bigbrother
+            3. Validate existing
+        """
+        new_library_object = _compare_bookmarks(self, self.library_object)
+
+        response = _create_bookmark_folder(self, 'bigbrother', 'Test Folder 2', listing_id=2)
+        # Verify bookmarks
+        new_library_object.search('/bigbrother/').add_folder_bookmark('Test Folder 2')
+        new_library_object.search('/bigbrother/Test Folder 2/').add_listing_bookmark('Air Mail')
+
+        new_library_object = _compare_bookmarks(self, new_library_object)
+
+        username = 'bigbrother'
+        url = '/api/bookmark/{}/'.format(response.data['id'])
+        response = APITestHelper.request(self, url, 'DELETE', username=username, status_code=204)
+
+        new_library_object.search_delete('/bigbrother/Test Folder 2/')
+
+        new_library_object = _compare_bookmarks(self, new_library_object)
+
+    def test_get_shared_folder_list_create_delete(self):
         """
         test_get_bookmark_list_shared_folder
 
         test checks for shared folders (InstrumentSharing)
         """
-        shared_folder_bookmarks = [
-            '(SF) InstrumentSharing',
-            ' (L) Acoustic Guitar',
-        ]
-
-        bigbrother2_expected_bookmarks = shared_folder_bookmarks + [
-            '(L) Alingano Maisu'
-        ]
-
-        julia_expected_bookmarks = shared_folder_bookmarks + [
-            '(L) Astrology software'
-        ]
-
-        johnson_expected_bookmarks = shared_folder_bookmarks + [
-            '(L) Applied Ethics Inc.'
-        ]
-
-        bigbrother2_bookmarks = _get_bookmarks_and_check_for_user(self, 'bigbrother2', bigbrother2_expected_bookmarks)  # OWNER
-        julia_bookmarks = _get_bookmarks_and_check_for_user(self, 'julia', julia_expected_bookmarks)  # OWNER
-        johnson_bookmarks = _get_bookmarks_and_check_for_user(self, 'johnson', johnson_expected_bookmarks)  # VIEWER
-
-        # Getting the id of the first shared folder
-        shared_folder_id = BookmarkFolder.parse_endpoint(bigbrother2_bookmarks).first_shared_folder().id
+        new_library_object = _compare_bookmarks(self, self.library_object)
+        shared_folder_id = new_library_object.search('/bigbrother2/').first_shared_folder().id
 
         response = _create_bookmark_listing(self, 'bigbrother2', 2, 'Air Mail', shared_folder_id)
-        # Add recently added bookmark to folder
-        shorten_shared_data = [' {}'.format(r) for r in BookmarkListing.parse_endpoint(response.data).shorten_data()]
-        shared_folder_bookmarks.extend(shorten_shared_data)
 
-        bigbrother2_expected_bookmarks = shared_folder_bookmarks + [
-            '(L) Alingano Maisu'
-        ]
+        new_library_object.search('/bigbrother2/').first_shared_folder().add_listing_bookmark('Air Mail')
+        new_library_object.search('/julia/').first_shared_folder().add_listing_bookmark('Air Mail')
+        new_library_object.search('/johnson/').first_shared_folder().add_listing_bookmark('Air Mail')
 
-        julia_expected_bookmarks = shared_folder_bookmarks + [
-            '(L) Astrology software'
-        ]
+        new_library_object = _compare_bookmarks(self, new_library_object)
 
-        johnson_expected_bookmarks = shared_folder_bookmarks + [
-            '(L) Applied Ethics Inc.'
-        ]
+        username = 'bigbrother2'
+        url = '/api/bookmark/{}/'.format(response.data['id'])
+        response = APITestHelper.request(self, url, 'DELETE', username=username, status_code=204)
 
-        # All users should be able to see the recently added bookmark under shared folder
-        bigbrother2_bookmarks = _get_bookmarks_and_check_for_user(self, 'bigbrother2', bigbrother2_expected_bookmarks)  # OWNER
-        julia_bookmarks = _get_bookmarks_and_check_for_user(self, 'julia', julia_expected_bookmarks)  # OWNER
-        johnson_bookmarks = _get_bookmarks_and_check_for_user(self, 'johnson', johnson_expected_bookmarks)  # VIEWER
+        new_library_object.search_delete('/bigbrother2/InstrumentSharing/Air Mail')
+        new_library_object.search_delete('/julia/InstrumentSharing/Air Mail')
+        new_library_object.search_delete('/johnson/InstrumentSharing/Air Mail')
 
-        # TODO: Delete recently added bookmark
+        _compare_bookmarks(self, new_library_object)
 
     def test_get_bookmark_list_shared_folder_permissions(self):
         """
@@ -265,21 +311,3 @@ class BookmarkApiTest(APITestCase):
         _get_folder_permission(self, 'johnson', shared_folder_id, bigbrother2_permission_shorthand_expected, status_code=403)
         # Check OTHER permission
         _get_folder_permission(self, 'bigbrother', shared_folder_id, bigbrother2_permission_shorthand_expected, status_code=403)
-
-    def test_listing_bookmark_owner_create_delete(self):
-        """
-        Test for creating listing bookmark under a non-shared folder and deleting same bookmark
-
-        Steps:
-            1. Validate existing bookmarks for bigbrother
-            2. Add a listing bookmark under root folder for bigbrother
-            3. Validate existing
-        """
-        # Verify bookmarks
-        _get_bookmarks_and_check_for_user(self, 'bigbrother', self.bigbrother_expected_bookmarks)
-
-        response = _create_bookmark_listing(self, 'bigbrother', 2, 'Air Mail')
-        # Verify bookmarks
-        shorten_shared_data = BookmarkListing.parse_endpoint(response.data).shorten_data()
-        expected_results = self.bigbrother_expected_bookmarks + shorten_shared_data
-        _get_bookmarks_and_check_for_user(self, 'bigbrother', expected_results)

--- a/tests/ozpcenter_api/test_api_bookmark.py
+++ b/tests/ozpcenter_api/test_api_bookmark.py
@@ -181,7 +181,21 @@ class BookmarkApiTest(APITestCase):
         """
         Check for bookmarks when listing owner disables listing, it should not be visable
         """
-        pass
+        new_library_object = _compare_bookmarks(self, self.library_object)
+
+        bigbrother_listing = new_library_object.search('/bigbrother/').first_listing_bookmark()
+        # Disable Listing
+        APITestHelper.edit_listing(self, bigbrother_listing.listing_id, {'is_enabled': False}, 'bigbrother')
+
+        bigbrother_listing.hidden(True)
+
+        _compare_bookmarks(self, new_library_object)
+
+        APITestHelper.edit_listing(self, bigbrother_listing.listing_id, {'is_enabled': True}, 'bigbrother')
+
+        bigbrother_listing.hidden(False)
+
+        _compare_bookmarks(self, new_library_object)
 
     def test_listing_bookmark_owner_create_delete(self):
         """

--- a/tests/ozpcenter_api/test_api_library.py
+++ b/tests/ozpcenter_api/test_api_library.py
@@ -152,44 +152,6 @@ class LibraryApiTest(APITestCase):
             ' (L) Azeroth',
             ' (L) Saturn'
         ]
-        #
-        # self.bigbrother_bookmark2 = [
-        #     '(F) Weather',
-        #     ' (L) Tornado',
-        #     ' (L) Lightning',
-        #     ' (L) Snow',
-        #     '(F) Animals',
-        #     ' (L) Wolf Finder',
-        #     ' (L) Killer Whale',
-        #     ' (L) Lion Finder',
-        #     ' (L) Monkey Finder',
-        #     ' (L) Parrotlet',
-        #     ' (L) White Horse',
-        #     '(F) Instruments',
-        #     ' (L) Electric Guitar',
-        #     ' (L) Acoustic Guitar',
-        #     ' (L) Sound Mixer',
-        #     ' (L) Electric Piano',
-        #     ' (L) Piano',
-        #     ' (L) Violin',
-        #     '(L) Bread Basket',
-        #     '(L) Informational Book',
-        #     '(L) Stop sign',
-        #     '(L) Chain boat navigation',
-        #     '(L) Gallery of Maps',
-        #     '(L) Chart Course'
-        # ]
-        #
-        # self.julia_bookmark2 = [
-        #     '(L) Astrology software',
-        # ]
-        #
-        # self.julia_bookmark2_weather_folder = [
-        #     '(F) Weather',
-        #     ' (L) Tornado',
-        #     ' (L) Lightning',
-        #     ' (L) Snow',
-        # ]
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
AMLNG-757

**Description**     
Endpoint to create a folder using a single listing (by id)

**Acceptance Criteria**   
I can see a purpose in creating a New Folder with a single listing id

Use case: from the listing page, create a new bookmark folder and put the listing in that folder.
 
**How to test code**    
```
POST /api/bookmark/
{ 
    "title": "Folder 1", 
    "type": "FOLDER",
     "listing":{"id":1}
}
```

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

