### PR TITLE
feat(profile): add avatar to short profile serializer

### DIFF
--- a/ozpcenter/api/listing/serializers.py
+++ b/ozpcenter/api/listing/serializers.py
@@ -190,11 +190,12 @@ class CreateListingUserSerializer(serializers.ModelSerializer):
 
 class CreateListingProfileSerializer(serializers.ModelSerializer):
     user = CreateListingUserSerializer()
+    avatar = image_serializers.ImageSerializer(allow_null=True)
 
     class Meta:
         model = models.Profile
-        fields = ('id', 'user', 'display_name')
-        read_only = ('id', 'display_name')
+        fields = ('id', 'user', 'display_name', 'avatar')
+        read_only = ('id', 'display_name', 'avatar')
 
         extra_kwargs = {
             "id": {

--- a/ozpcenter/api/profile/serializers.py
+++ b/ozpcenter/api/profile/serializers.py
@@ -284,11 +284,12 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 
 class ShortProfileSerializer(serializers.ModelSerializer):
+    avatar = ImageSerializer(allow_null=True)
     user = ShortUserSerializer()
 
     class Meta:
         model = models.Profile
-        fields = ('id', 'user', 'display_name', 'dn')
+        fields = ('id', 'user', 'display_name', 'dn', 'avatar')
 
     def to_representation(self, data):
         access_control_instance = plugin_manager.get_system_access_control_plugin()

--- a/tests/ozpcenter_api/test_api_listing.py
+++ b/tests/ozpcenter_api/test_api_listing.py
@@ -145,7 +145,7 @@ class ListingApiTest(APITestCase):
             {'key': 'contacts', 'exclude': ['id', 'organization']},
             {'key': 'categories', 'exclude': ['id', 'description']},
             {'key': 'tags', 'exclude': ['id']},
-            {'key': 'owners', 'exclude': ['id', 'display_name']},
+            {'key': 'owners', 'exclude': ['id', 'display_name', 'avatar']},
             {'key': 'intents', 'exclude': ['id', 'icon', 'label', 'media_type']},
             {'key': 'doc_urls', 'exclude': ['id']},
             {'key': 'screenshots', 'exclude': ['small_image.security_marking', 'large_image.security_marking', 'small_image.url', 'large_image.url', 'order', 'description']},
@@ -361,7 +361,7 @@ class ListingApiTest(APITestCase):
             {'key': 'contacts', 'exclude': ['id', 'organization']},
             {'key': 'categories', 'exclude': ['id', 'description']},
             {'key': 'tags', 'exclude': ['id']},
-            {'key': 'owners', 'exclude': ['id', 'display_name']},
+            {'key': 'owners', 'exclude': ['id', 'display_name', 'avatar']},
             {'key': 'intents', 'exclude': ['id', 'icon', 'label', 'media_type']},
             {'key': 'doc_urls', 'exclude': ['id']},
             {'key': 'screenshots', 'exclude': ['small_image.security_marking', 'large_image.security_marking', 'small_image.url', 'large_image.url', 'order']},
@@ -649,6 +649,7 @@ class ListingApiTest(APITestCase):
           "owners": [
             {
               "display_name": "Big Brother",
+              "avatar": None,
               "id": 4,
               "user": {
                 "username": "bigbrother"


### PR DESCRIPTION
AMLOS-753

**Description**     
As a user I want to view another user's profile to view their contact info, org, avatar, and possibly applications they own.

**Acceptance Criteria**   
A user can go to a link (through a listing, or directly) that will display the profile info of another user
 
**How to test code**    
Backend support for this ticket.

Pull this branch
You may want to change user avatars via the 3.0 edit profile page

When viewing a listing through the API, verify that the data for each owner contains information about the profile's avatar, or `"avatar": null` if the user does not have one.  Example payload:
```
"owners": [
      {
        "id": 1,
        "user": {
          "username": "bigbrother"
        },
        "display_name": "Big Brother",
        "avatar": {
          "url": "http://localhost:8001/api/image/1238/",
          "id": 1238,
          "security_marking": "UNCLASSIFIED"
        }
      }
    ]
```
Same applies to listing activity and reviews.

To test the frontend, refer to https://github.com/aml-development/frontend/pull/147

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

