### PR TITLE
feat(listing): add API listing_type

### DIFF
--- a/ozpcenter/api/bookmark/serializers.py
+++ b/ozpcenter/api/bookmark/serializers.py
@@ -27,13 +27,14 @@ class LibraryListingSerializer(serializers.HyperlinkedModelSerializer):
     large_icon = image_serializers.ImageSerializer(required=False)
     banner_icon = image_serializers.ImageSerializer(required=False)
     owners = listing_serializers.CreateListingProfileSerializer(required=False, allow_null=True, many=True)
+    listing_type = listing_serializers.ListingTypeSerializer(required=False, allow_null=True)
 
     class Meta:
         model = models.Listing
         fields = ('id', 'title', 'unique_name', 'launch_url', 'small_icon',
-            'large_icon', 'banner_icon', 'owners', 'security_marking', 'is_enabled')
+            'large_icon', 'banner_icon', 'owners', 'security_marking', 'is_enabled', 'listing_type')
         read_only_fields = ('title', 'unique_name', 'launch_url', 'small_icon',
-            'large_icon', 'banner_icon', 'owners', 'security_marking', 'is_enabled')
+            'large_icon', 'banner_icon', 'owners', 'security_marking', 'is_enabled', 'listing_type')
         # Any AutoFields on your model (which is what the automatically
         # generated id key is) are set to read-only by default when Django
         # REST Framework is creating fields in the background. read-only fields

--- a/ozpcenter/api/storefront/serializers.py
+++ b/ozpcenter/api/storefront/serializers.py
@@ -20,6 +20,7 @@ class StorefrontListingSerializer(serializers.HyperlinkedModelSerializer):
     large_banner_icon = image_serializers.ImageSerializer(required=False, allow_null=True)
     banner_icon = image_serializers.ImageSerializer(required=False, allow_null=True)
     owners = listing_serializers.CreateListingProfileSerializer(required=False, allow_null=True, many=True)
+    listing_type = listing_serializers.ListingTypeSerializer(required=False, allow_null=True)
 
     class Meta:
         model = models.Listing
@@ -41,7 +42,8 @@ class StorefrontListingSerializer(serializers.HyperlinkedModelSerializer):
                   'banner_icon',
                   'owners',
                   'unique_name',
-                  'is_enabled')
+                  'is_enabled',
+                  'listing_type')
 
     def _is_bookmarked(self, request_user, request_listing):
         # TODO: put in listing model_access.py call from there > creative name for method

--- a/ozpcenter/scripts/test_data/listing_types.yaml
+++ b/ozpcenter/scripts/test_data/listing_types.yaml
@@ -9,3 +9,5 @@ listing_types:
   title: Web Services
 - description: widget things
   title: Widget
+- description: external apis
+  title: API

--- a/ozpcenter/scripts/test_data/listings.yaml
+++ b/ozpcenter/scripts/test_data/listings.yaml
@@ -13847,7 +13847,7 @@
     large_banner_icon: {filename: Writing_large_banner_icon.jpeg, security_marking: UNCLASSIFIED}
     large_icon: {filename: Writing_large_icon.jpeg, security_marking: UNCLASSIFIED}
     launch_url: https://en.wikipedia.org/wiki/Writing
-    listing_type: Web Application
+    listing_type: API
     owners: [bigbrother]
     screenshots:
     - description: Writing down on a piece of paper
@@ -13863,6 +13863,92 @@
     usage_requirements: A pen and paper
     version_name: '15.05'
     what_is_new: It is possible to also write using a laptop
+  listing_activity:
+  - {action: CREATED, author: bigbrother, description: null}
+  - {action: SUBMITTED, author: bigbrother, description: null}
+  - {action: APPROVED_ORG, author: bigbrother, description: null}
+  - {action: APPROVED, author: bigbrother, description: null}
+  listing_review_batch: []
+  listing_visit_count:
+  - {count: 1, profile: betaraybill}
+  - {count: 2, profile: bigbrother}
+  - {count: 3, profile: rutherford}
+  - {count: 4, profile: julia}
+  - {count: 4, profile: noah}
+  - {count: 5, profile: aaronson}
+  - {count: 5, profile: johnson}
+  - {count: 6, profile: charrington}
+  - {count: 6, profile: wsmith}
+  - {count: 7, profile: jsnow}
+  - {count: 8, profile: bettafish}
+  - {count: 8, profile: syme}
+  - {count: 9, profile: abe}
+  - {count: 9, profile: khaleesi}
+  - {count: 9, profile: david}
+  - {count: 9, profile: obrien}
+- library_entries: []
+  library_sharing: []
+  listing:
+    agency: Minipax
+    banner_icon: {filename: Writing_banner_icon.jpeg, security_marking: UNCLASSIFIED}
+    categories: [Communication, Tools]
+    contacts: []
+    description: Web APIs are the defined interfaces through which interactions
+      happen between an enterprise and applications that use its assets, which also is
+      a Service Level Agreement (SLA) to specify the functional provider and expose the
+      service path or URL for its API users, An API approach is an architectural
+      approach that revolves around providing a program interface to a set of services
+      to different applications serving different types of consumers.[17] When used in
+      the context of web development, an API is typically defined a set of
+      specifications , such as Hypertext Transfer Protocol (HTTP) request messages,
+      along with a definition of the structure of response messages, which is usually
+      in an Extensible Markup Language (XML) or JavaScript Object Notation (JSON)
+      format. An example might be a shipping company API that can be added to an
+      eCommerce-focused website, to facilitate ordering shipping services and
+      automatically include current shipping rates, without the site developer having
+      to enter the shipper's rate table into a web database. While "web API"
+      historically has been virtually synonymous for web service, the recent trend
+      (so-called Web 2.0) has been moving away from Simple Object Access Protocol
+      (SOAP) based web services and service-oriented architecture (SOA) towards more
+      direct representational state transfer (REST) style web resources and
+      resource-oriented architecture (ROA).[18] Part of this trend is related to the
+      Semantic Web movement toward Resource Description Framework (RDF), a concept to
+      promote web-based ontology engineering technologies. Web APIs allow the
+      combination of multiple APIs into new applications known as mashups.[19] In the
+      social media space, web APIs have allowed web communities to facilitate sharing
+      content and data between communities and applications. In this way, content that
+      is created in one place can be dynamically posted and updated in multiple
+      locations on the web.[20] For example, Twitter's REST API allows developers to
+      access core Twitter data and the Search API provides methods for developers to
+      interact with Twitter Search and trends data.
+    description_short: In computer programming, an application programming interface
+      (API) is a set of subroutine definitions, protocols, and tools for building
+      software
+    doc_urls: []
+    iframe_compatible: false
+    is_deleted: false
+    is_enabled: true
+    is_featured: false
+    is_private: false
+    large_banner_icon: {filename: Writing_large_banner_icon.jpeg, security_marking: UNCLASSIFIED}
+    large_icon: {filename: Writing_large_icon.jpeg, security_marking: UNCLASSIFIED}
+    launch_url: https://en.wikipedia.org/wiki/Application_programming_interface
+    listing_type: API
+    owners: [bigbrother]
+    screenshots:
+    - description: Writing down on a piece of paper
+      large_image: {filename: Writing_0_large_screenshot.jpeg, security_marking: UNCLASSIFIED}
+      order: 0
+      small_image: {filename: Writing_0_small_screenshot.jpeg, security_marking: UNCLASSIFIED}
+    security_marking: UNCLASSIFIED//FOR OFFICIAL USE ONLY
+    small_icon: {filename: Writing_small_icon.jpeg, security_marking: UNCLASSIFIED}
+    system_requirements: None
+    tags: [computer, IT, development, code]
+    title: Application programming interface
+    unique_name: Application programming interface
+    usage_requirements: A computer
+    version_name: '42'
+    what_is_new: Oracle America, Inc. v. Google, Inc.
   listing_activity:
   - {action: CREATED, author: bigbrother, description: null}
   - {action: SUBMITTED, author: bigbrother, description: null}

--- a/tests/ozpcenter/recommend/test_graph_factory.py
+++ b/tests/ozpcenter/recommend/test_graph_factory.py
@@ -27,7 +27,7 @@ class GraphTest(TestCase):
 
     def test_load_db_into_graph(self):
         graph = GraphFactory.load_db_into_graph()
-        self.assertEqual(str(graph), 'Graph(vertices: 222, edges: 533)')
+        self.assertEqual(str(graph), 'Graph(vertices: 223, edges: 536)')
 
         bigbrother_dict = graph.query().v('p-1').to_dict().next()
         expected_dict = {'highest_role': 'APPS_MALL_STEWARD', 'username': 'bigbrother'}

--- a/tests/ozpcenter/recommend/test_recommend_es.py
+++ b/tests/ozpcenter/recommend/test_recommend_es.py
@@ -62,15 +62,15 @@ class ElasticsearchBaseRecommenderTest(APITestCase):
 
         expected_result = [
             '(_score:(Elasticsearch Content Filtering:(raw_score:8.762,weight:0.9),_sort_score:7.886),title:Wolverine)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.315,weight:0.9),_sort_score:7.483),title:Beast)',
+            '(_score:(Elasticsearch Content Filtering:(raw_score:8.316,weight:0.9),_sort_score:7.484),title:Beast)',
             '(_score:(Elasticsearch Content Filtering:(raw_score:8.268,weight:0.9),_sort_score:7.441),title:Magneto)',
             '(_score:(Elasticsearch Content Filtering:(raw_score:8.213,weight:0.9),_sort_score:7.392),title:Jupiter)',
             '(_score:(Elasticsearch Content Filtering:(raw_score:8.112,weight:0.9),_sort_score:7.301),title:Pokemon Ruby and Sapphire)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.096,weight:0.9),_sort_score:7.286),title:Cyclops)',
+            '(_score:(Elasticsearch Content Filtering:(raw_score:8.097,weight:0.9),_sort_score:7.287),title:Cyclops)',
             '(_score:(Elasticsearch Content Filtering:(raw_score:8.094,weight:0.9),_sort_score:7.285),title:Barsoom)',
             '(_score:(Elasticsearch Content Filtering:(raw_score:8.088,weight:0.9),_sort_score:7.279),title:Blink)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.08,weight:0.9),_sort_score:7.272),title:Clerks)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:7.999,weight:0.9),_sort_score:7.199),title:Rogue)'
+            '(_score:(Elasticsearch Content Filtering:(raw_score:8.082,weight:0.9),_sort_score:7.274),title:Clerks)',
+            '(_score:(Elasticsearch Content Filtering:(raw_score:7.998,weight:0.9),_sort_score:7.198),title:Rogue)'
         ]
 
         # import json; print(json.dumps(title_scores, indent=4))

--- a/tests/ozpcenter/test_data_util.py
+++ b/tests/ozpcenter/test_data_util.py
@@ -24,11 +24,11 @@ class DataUtilTest(TestCase):
         query = data_util.FileQuery()
         query = query.load_yaml_file()
 
-        self.assertEqual(188, query.count())
+        self.assertEqual(189, query.count())
 
     def test_file_query_load_yaml_key(self):
         query = data_util.FileQuery().load_yaml_file().key('listing').key('title')
 
         listing_title = query.to_list()
 
-        self.assertEqual(188, len(listing_title))
+        self.assertEqual(189, len(listing_title))

--- a/tests/ozpcenter_api/test_api_listing.py
+++ b/tests/ozpcenter_api/test_api_listing.py
@@ -768,17 +768,17 @@ class ListingApiTest(APITestCase):
         last_item = data[-1]
 
         expected_item = {"counts": {
-            "APPROVED": 176,
+            "APPROVED": 177,
             "APPROVED_ORG": 1,
             "DELETED": 0,
             "IN_PROGRESS": 0,
             "PENDING": 10,
             "PENDING_DELETION": 0,
-            "enabled": 183,
+            "enabled": 184,
             "REJECTED": 0,
             "organizations": {
               "1": 44,
-              "2": 42,
+              "2": 43,
               "3": 49,
               "4": 37,
               "5": 5,
@@ -787,7 +787,7 @@ class ListingApiTest(APITestCase):
               "8": 3,
               "9": 2
             },
-            "total": 187
+            "total": 188
           }
         }
         self.assertEqual(last_item, expected_item)

--- a/tests/ozpcenter_api/test_api_listing_search_es.py
+++ b/tests/ozpcenter_api/test_api_listing_search_es.py
@@ -165,7 +165,7 @@ class ListingESSearchApiTest(APITestCase):
         response = APITestHelper.request(self, url, 'GET', username='wsmith', status_code=200)
 
         titles = sorted([i['title'] for i in response.data['results']])
-        expected_listing = ['Air Mail', 'Bread Basket', 'Chart Course', 'Chatter Box', 'Clipboard',
+        expected_listing = ['Air Mail', 'Application programming interface', 'Bread Basket', 'Chart Course', 'Chatter Box', 'Clipboard',
             'Deadpool', 'Desktop Virtualization', 'Diamond', 'Dinosaur', 'Dragons', 'FrameIt',
             'Harley-Davidson CVO', 'Hatch Latch', 'JotSpot', 'LocationAnalyzer', 'LocationLister',
             'LocationViewer', 'Mini Dachshund', 'Monkey Finder', 'Personal Computer', 'Ruby on Rails',

--- a/tests/ozpcenter_api/test_api_listing_similiar.py
+++ b/tests/ozpcenter_api/test_api_listing_similiar.py
@@ -61,6 +61,7 @@ class ListingSimilarApiTest(APITestCase):
         titles = ['{}'.format(i['title']) for i in response.data]
 
         expected_results = ['Air Mail',
+                            'Application programming interface',
                             'Barsoom',
                             'Bass Fishing',
                             'BeiDou Navigation Satellite System',
@@ -68,7 +69,6 @@ class ListingSimilarApiTest(APITestCase):
                             'Bourbon',
                             'Cable ferry',
                             'Chain boat navigation',
-                            'Chatter Box',
-                            'Desktop Virtualization']
+                            'Chatter Box']
 
         self.assertListEqual(titles, expected_results)

--- a/tests/ozpcenter_api/test_api_storefront.py
+++ b/tests/ozpcenter_api/test_api_storefront.py
@@ -135,7 +135,7 @@ class StorefrontApiTest(APITestCase):
         desired_keys = ['id', 'title', 'agency', 'avg_rate',
             'total_reviews', 'feedback_score', 'is_private', 'is_bookmarked',
             'feedback', 'description_short', 'security_marking',
-            'usage_requirements', 'system_requirements', 'launch_url',
+            'usage_requirements', 'system_requirements', 'launch_url', 'listing_type',
             'large_banner_icon', 'banner_icon', 'unique_name', 'is_enabled', 'owners']
         desired_keys += additional_keys
         desired_keys = sorted(desired_keys)


### PR DESCRIPTION
Adds API Listing type ti test_data
Add listing type to bookmark serializer
Add listing type to storefront serializer
Add test listing and resolve any conflicts created

Closes #AMLOS-766

**Description**     
Review additional fields needed for API listings and add them to the backend endpoint.
 
**How to test code**    
Pull this branch. Run make dev.
you should see api listing type in metadata
you should see listing type in bookmark api objects
you should see listing type in storefront api objects.
Pull https://github.com/aml-development/frontend/tree/api_listing and view the frontend changes to listing 188 and new listing 189.
 
**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

