### PR TITLE
feat(listing): filter listing updates per user

### DIFF
--- a/ozpcenter/api/listing/views.py
+++ b/ozpcenter/api/listing/views.py
@@ -377,7 +377,7 @@ class ListingActivitiesViewSet(viewsets.ModelViewSet):
     Response:
         200 - Successful operation - ListingActivitySerializer
     """
-    permission_classes = (permissions.IsOrgSteward,)
+    permission_classes = (permissions.IsUser,)
     serializer_class = serializers.ListingActivitySerializer
 
     def get_queryset(self):

--- a/tests/ozpcenter_api/test_api_listing_activites.py
+++ b/tests/ozpcenter_api/test_api_listing_activites.py
@@ -132,7 +132,9 @@ class ListingActivitiesApiTest(APITestCase):
         expected_titles = ['Air Mail', 'Bread Basket', 'Chart Course', 'Chatter Box', 'Clipboard']
 
         # Ensure that Standard Users can not access /api/listing/activity
-        APITestHelper.request(self, url, 'GET', username='jones', status_code=403)
+        # APITestHelper.request(self, url, 'GET', username='jones', status_code=403)
+        # (July 30 2018) AMLOS-712 Filter listing updates per user
+        APITestHelper.request(self, url, 'GET', username='jones', status_code=200)
 
         # Ensure that ORG_STEWARDS can access endpoint
         response = APITestHelper.request(self, url, 'GET', username='wsmith', status_code=200)


### PR DESCRIPTION
AMLOS-712

**Description**     
It appears that the current /api/listings/activity API only returns results to users that are admins/stewards (bigbrother for example can see results, but betaraybill receives a forbidden error).  It could be worthwhile to check permissions of the user and filter the results from the API to show updates to any listing that the user has access to.
For example, remove updates for private apps that the user is not in the same org, but show updates for apps that the user can view.
If filtering the current API is too much of a hassle, then a new API, or a 'self' API, could be used in its place.

**Acceptance Criteria**   
An API is available that returns updates to apps/listings that is filtering to only listings the user is allowed to see.  No user is forbidden from receiving data from the API.
 
**How to test code**    
`make test_parallel` 

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

