### PR TITLE
feat(bookmarks): filter shared and non-shared

### DIFF
--- a/ozpcenter/utils.py
+++ b/ozpcenter/utils.py
@@ -30,8 +30,10 @@ def str_to_bool(user_input):
     else:
         if '{}'.format(user_input).lower() in ['1', 'true']:
             return True
-        else:
+        elif '{}'.format(user_input).lower() in ['0', 'false']:
             return False
+        else:
+            return None
 
 
 def interactive_migration():


### PR DESCRIPTION
AMLOS-747

**Description**     
Filter by Shared / Not-Shared bookmark folders

**Acceptance Criteria**   
The bookmark endpoint allows a user to filter the bookmarks seen by shared / not-shared bookmark folders in addition to sorting.
 
**How to test code**    
```
make test_parallel
``` 

Show Shared Bookmarks
```
GET /api/bookmark/?is_shared=true
```

Show Non-Shared Bookmarks
```
GET /api/bookmark/?is_shared=false
```

Show Shared and Non-Shared Bookmarks
```
GET /api/bookmark/?is_shared=none
GET /api/bookmark/
```

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [ ] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

