### PR TITLE
feat(es): upgrade to elasticsearch 6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    -  ES_VERSION=6.3.2 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
+    -  ES_VERSION=6.3.2 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
   matrix:
     - DB=sqlite TEST_FOLDER="tests/ozp tests/ozpcenter"
     - DB=sqlite TEST_FOLDER="tests/ozpcenter_api"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - ES_VERSION=2.4.6 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz
+    -  ES_VERSION=6.3.2 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
   matrix:
     - DB=sqlite TEST_FOLDER="tests/ozp tests/ozpcenter"
     - DB=sqlite TEST_FOLDER="tests/ozpcenter_api"

--- a/docs/features/elasticsearch_upgrade_2.x_6.x.md
+++ b/docs/features/elasticsearch_upgrade_2.x_6.x.md
@@ -1,0 +1,22 @@
+# ElasticSearch Upgrade 2.4 to 6.3
+
+## Knowledge Prerequisite
+```
+https://www.elastic.co/guide/en/elasticsearch/reference/6.3/getting-started.html
+https://www.elastic.co/guide/en/elasticsearch/reference/6.3/mapping.htm
+https://www.elastic.co/guide/en/elasticsearch/reference/6.3/search-analyzer.html
+```
+
+## Affected areas of code
+```
+ozpcenter/api/listing/elasticsearch_util.py
+ozpcenter/api/listing/model_access_es.py
+ozpcenter/recommend/recommend_es.py
+```
+
+## Steps
+* Understand differences between 2.4 and 6.3
+* Follow Getting Started Page on ElasticSearch website
+* Update Python Elasticsearch dependency
+    * https://elasticsearch-py.readthedocs.io/en/master/
+* Update `Affected areas of code`

--- a/ozpcenter/api/listing/model_access_es.py
+++ b/ozpcenter/api/listing/model_access_es.py
@@ -350,8 +350,11 @@ def search(request_username, search_param_parser):
     user_exclude_orgs = get_user_exclude_orgs(request_username)
     search_query = elasticsearch_util.make_search_query_obj(search_param_parser, exclude_agencies=user_exclude_orgs)
 
-    # print(json.dumps(search_query, indent=4))
-    res = es_client.search(index=settings.ES_INDEX_NAME, body=search_query)
+    try:
+        res = es_client.search(index=settings.ES_INDEX_NAME, body=search_query)
+    except Exception as err:
+        print(json.dumps(search_query, indent=4))
+        raise err
 
     hits = res.get('hits', {})
     inner_hits = hits.get('hits', None)

--- a/ozpcenter/scripts/recommend.py
+++ b/ozpcenter/scripts/recommend.py
@@ -5,8 +5,10 @@ settings.py/or this file?
 -----
 recommendation_engines = ['ElasticsearchUserBaseRecommender', 'ElasticsearchContentBaseRecommender', 'CrabUserBaseRecommender']
 ----
-
 os.getenv('RECOMMENDATION_ENGINE')
+
+
+ES_ENABLED=True RECOMMENDATION_ENGINE=elasticsearch_content_base python manage.py runscript recommend
 
 ************************************WARNING************************************
 Running this script will delete existing Recommendations in database

--- a/ozpcenter/scripts/show_es_api_calls.py
+++ b/ozpcenter/scripts/show_es_api_calls.py
@@ -1,0 +1,39 @@
+"""
+Show API Calls for ElasticSearch 6.x
+
+python manage.py runscript show_es_api_calls > es.sh
+
+
+https://www.elastic.co/guide/en/elasticsearch/reference/6.3/indices-create-index.html#mappings
+"""
+import sys
+import os
+import json
+
+sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from ozpcenter.api.listing import elasticsearch_util
+
+URL_PATH = 'http://127.0.0.1:9200'
+INDEX_NAME = 'aml_listing_data'
+
+
+def run():
+    """
+    Reindex Data
+    """
+    mapping_object = elasticsearch_util.get_mapping_setting_obj()
+    mapping_object_json = json.dumps(mapping_object, indent=2)
+
+    commands = []
+
+    commands.append('echo \'DELETE INDEX\'')
+    commands.append('curl -X DELETE "{}/{}"'.format(URL_PATH, INDEX_NAME))
+    commands.append('echo \'\'')
+
+    commands.append('echo \'Creating Listing data INDEX\'')
+    commands.append('curl -X PUT "{}/{}" -H \'Content-Type: application/json\' -d\'\n{}\n\''.format(URL_PATH, INDEX_NAME, mapping_object_json))
+    commands.append('echo \'\'')
+    commands.append('# -----------------------')
+
+    print('\n'.join(commands))

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -16,7 +16,7 @@ boto3==1.4.7
 Pillow==4.2.1
 psycopg2==2.7.3.1
 
-elasticsearch==5.4.0
+elasticsearch==6.3.0
 gunicorn==19.7.1
 
 PyYAML==3.12

--- a/tests/ozpcenter/recommend/test_recommend_es.py
+++ b/tests/ozpcenter/recommend/test_recommend_es.py
@@ -25,6 +25,7 @@ class ElasticsearchBaseRecommenderTest(APITestCase):
         """
         setUp is invoked before each test method
         """
+        self.maxDiff = None
         self.error_string = None
         self.es_failed = False
         try:
@@ -61,19 +62,20 @@ class ElasticsearchBaseRecommenderTest(APITestCase):
         title_scores = shorthand_dict(title_scores)
 
         expected_result = [
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.762,weight:0.9),_sort_score:7.886),title:Wolverine)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.316,weight:0.9),_sort_score:7.484),title:Beast)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.268,weight:0.9),_sort_score:7.441),title:Magneto)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.213,weight:0.9),_sort_score:7.392),title:Jupiter)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.112,weight:0.9),_sort_score:7.301),title:Pokemon Ruby and Sapphire)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.097,weight:0.9),_sort_score:7.287),title:Cyclops)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.094,weight:0.9),_sort_score:7.285),title:Barsoom)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.088,weight:0.9),_sort_score:7.279),title:Blink)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:8.082,weight:0.9),_sort_score:7.274),title:Clerks)',
-            '(_score:(Elasticsearch Content Filtering:(raw_score:7.998,weight:0.9),_sort_score:7.198),title:Rogue)'
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.762,weight:0.9),_sort_score:7.886),title:BeiDou Navigation Satellite System)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.677,weight:0.9),_sort_score:7.809),title:Rogue)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.572,weight:0.9),_sort_score:7.715),title:Wolverine)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.544,weight:0.9),_sort_score:7.69),title:Navigation using Maps)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.475,weight:0.9),_sort_score:7.627),title:Neptune)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.439,weight:0.9),_sort_score:7.595),title:Komodo Dragon)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.303,weight:0.9),_sort_score:7.473),title:Magneto)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.283,weight:0.9),_sort_score:7.455),title:Jupiter)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.273,weight:0.9),_sort_score:7.446),title:Uranus)",
+            "(_score:(Elasticsearch Content Filtering:(raw_score:8.261,weight:0.9),_sort_score:7.435),title:Cyclops)"
         ]
 
-        # import json; print(json.dumps(title_scores, indent=4))
+        import json
+        print(json.dumps(title_scores, indent=4))
         self.assertEquals(expected_result, title_scores)
 
     @override_settings(ES_ENABLED=True)


### PR DESCRIPTION
AMLOS-399
AMLOS-462

**Description**     
Document how upgrading to Elasticsearch 6.x will impact code changes needed
Upgrade to Elasticsearch 6.3.2

**Acceptance Criteria**   
Code base has been upgraded to use Elasticsearch 6.3.2
 
**How to test code**    
Download Elasticsearch
```
ES_VERSION=6.3.2 
ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
wget ${ES_DOWNLOAD_URL}
tar -xzf elasticsearch-${ES_VERSION}.tar.gz
./elasticsearch-${ES_VERSION}/bin/elasticsearch
```
Create a new python environment
```
rm -rf env
make pyenv
source env/bin/activate
```
Run Unit test and run server 
```
make test_parallel
make dev reindex_es
make run
```
Run Curl Command to test search
```
curl -X GET \
  'http://127.0.0.1:8001/api/listings/essearch/?search=demo_tag&type=Web%20Application' \
  -H 'authorization: Basic YmlnYnJvdGhlcjpwYXNzd29yZA==' \
```
Optional Step: Under `settings.py` change ES_HOST to correct port number. If Elasticsearch 2.3 is also running then port for Elasticsearch 6.3 will be 9201
```
ES_HOST = [{
    "host": "localhost",
    "port": 9200
}]
```

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

