### PR TITLE
fix(storefront): change sort behavior

### DIFF
--- a/ozpcenter/api/profile/views.py
+++ b/ozpcenter/api/profile/views.py
@@ -155,8 +155,6 @@ class ProfileListingViewSet(viewsets.ModelViewSet):
     def get_queryset(self, profile_pk=None, listing_pk=None):
         current_request_username = self.request.user.username
         ordering = self.request.query_params.get('ordering', None)
-        if ordering:
-            ordering = [s.strip() for s in ordering.split(',')]
 
         queryset = model_access.get_all_listings_for_profile_by_id(current_request_username, profile_pk, listing_pk, ordering)
         return queryset
@@ -286,8 +284,7 @@ class ProfileListingVisitCountViewSet(viewsets.ModelViewSet):
         """
         current_request_username = request.user.username
         ordering = request.query_params.get('ordering', None)
-        if ordering:
-            ordering = [s.strip() for s in ordering.split(',')]
+
         # Used to anonymize usernames
         anonymize_identifiable_data = system_anonymize_identifiable_data(current_request_username)
 

--- a/ozpcenter/api/storefront/views.py
+++ b/ozpcenter/api/storefront/views.py
@@ -76,8 +76,6 @@ class StorefrontViewSet(viewsets.ViewSet):
         """
         debug_recommendations = str_to_bool(request.query_params.get('debug_recommendations', False))
         ordering = request.query_params.get('ordering', None)
-        if ordering:
-            ordering = [s.strip() for s in ordering.split(',')]
 
         data, extra_data = model_access.get_storefront(request, True, ordering=ordering)
         serializer = serializers.StorefrontSerializer(data, context={'request': request})
@@ -90,8 +88,6 @@ class StorefrontViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk=None):
         debug_recommendations = str_to_bool(request.query_params.get('debug_recommendations', False))
         ordering = request.query_params.get('ordering', None)
-        if ordering:
-            ordering = [s.strip() for s in ordering.split(',')]
 
         data, extra_data = model_access.get_storefront(request, True, pk, ordering=ordering)
         serializer = serializers.StorefrontSerializer(data, context={'request': request})

--- a/ozpcenter/recommend/recommend.py
+++ b/ozpcenter/recommend/recommend.py
@@ -117,14 +117,13 @@ class RecommenderProfileResultSet(object):
         self.recommender_result_set = {}
 
     @staticmethod
-    def from_profile_instance(profile_instance, randomize_recommended=True, ordering=None):
+    def from_profile_instance(profile_instance, randomize_recommended=True):
         """
         Factory Method to create a RecommenderProfileResultSet from the database
         """
         recommender_profile_result_set = RecommenderProfileResultSet(profile_instance.id)
         recommender_profile_result_set.profile_instance = profile_instance
         recommender_profile_result_set.randomize_recommended = randomize_recommended
-        recommender_profile_result_set.ordering = ordering
 
         # Get Recommended Listings for owner
         target_profile_recommended_entry = models.RecommendationsEntry.objects.filter(target_profile=profile_instance).first()
@@ -238,26 +237,18 @@ class RecommenderProfileResultSet(object):
                                                       is_enabled=True,
                                                       is_deleted=False)
                                               .exclude(id__in=self.filter_listing_ids))
-        if self.ordering:
-            self.recommended_listings_queryset = self.recommended_listings_queryset.order_by(*self.ordering)
         self.recommended_listings_queryset = self.recommended_listings_queryset.all()
 
     def _fix_recommendation_order(self):
-        if self.ordering:
-            # Use same ordering as the queryset
-            self.recommended_listings_raw = []
-            for listing_object in self.recommended_listings_queryset:
-                self.recommended_listings_raw.append(listing_object)
-        else:
-            # Fix Order of Recommendations based of score
-            listing_id_object_mapper = {}
-            for listing_object in self.recommended_listings_queryset:
-                listing_id_object_mapper[listing_object.id] = listing_object
+        # Fix Order of Recommendations based of score
+        listing_id_object_mapper = {}
+        for listing_object in self.recommended_listings_queryset:
+            listing_id_object_mapper[listing_object.id] = listing_object
 
-            self.recommended_listings_raw = []
-            for listing_id in self.sorted_recommendation_listing_ids:
-                if listing_id in listing_id_object_mapper:
-                    self.recommended_listings_raw.append(listing_id_object_mapper[listing_id])
+        self.recommended_listings_raw = []
+        for listing_id in self.sorted_recommendation_listing_ids:
+            if listing_id in listing_id_object_mapper:
+                self.recommended_listings_raw.append(listing_id_object_mapper[listing_id])
 
     def _get_recommended_listings(self):
         profile_username = self.profile_instance.user.username


### PR DESCRIPTION
AMLOS-796

**Description**     
Sort By on Most Popular was an after-thought on 2.0. It might not make sense on 3.0, particularly when the data set is limited. We'll either remove the Sort By option, or add the ability to expand out the data set.

**Acceptance Criteria**   
Based on discussion around this ticket, the sort behavior on all storefront sections and on profile listings (my listings, frequently visited listings) is changed as follows:

- Sections return listings sorted in their default order
- When a custom ordering is set, those listings are sorted in that custom order
 
**How to test code**    
Pull this branch

For testing the frontend,
- Go to the storefront on AML 3.0
- For each _See More_ page, check that the default sort returns listings as expected
- Check that changing the sort correctly sorts those listings
- For example, _Most Popular_ should return 36 listings, sorted first by average rating, then total votes (highest to lowest).  Changing the sort to _Title: A to Z_ should alphabetically sort those same 36 listings

For testing the API calls, see https://github.com/aml-development/ozp-backend/pull/455

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

