### PR TITLE
fix(storefront): case insensitive sorting

### DIFF
--- a/ozpcenter/api/storefront/model_access.py
+++ b/ozpcenter/api/storefront/model_access.py
@@ -456,9 +456,18 @@ def custom_sort_listings(listings, ordering_str):
 
     ordering = [s.strip() for s in ordering_str.split(',')]
     listing_ids = [x.id for x in listings]
-    sorted_listings = models.Listing.objects.filter(id__in=listing_ids).order_by(*ordering)
+    sorted_listings = models.Listing.objects.filter(id__in=listing_ids)
+    for field in ordering:
+        if 'title' in field:
+            # case insensitive sort for title
+            if field.startswith('-'):
+                sorted_listings = sorted_listings.order_by(Lower(field[1:])).reverse()
+            else:
+                sorted_listings = sorted_listings.order_by(Lower(field))
+        else:
+            sorted_listings = sorted_listings.order_by(field)
 
-    return sorted_listings
+    return sorted_listings.all()
 
 
 def values_query_set_to_dict(vqs):


### PR DESCRIPTION
AMLOS-827

**Description**     
On my Local instance, 

Go to create a listing,
Submit listing named "butterfly", Approve Listing
Refresh Listing appears in the Recently Added.
Now See More
Select the Sort Title: A to Z
Results: My "butterfly" Listing is last instead of 2nd in the grouping. (See screenshot)

Sort needs to be case insensitive.  This behavior is caused because "butterfly" starts with a lower case b.

**Acceptance Criteria**   
See More pages on storefront will do a case insensitive sort when sorting by _Title: A to Z_, _Title: Z to A_
 
**How to test code**    
Pull this branch
Validate acceptance criteria 

**Please Review**     
@aml-development/ozp-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [x] At least 2 people reviewed code

